### PR TITLE
Update AmmoDef.cs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -28,7 +28,11 @@ namespace CombatExtended
                     users = CE_Utility.allWeaponDefs.FindAll(delegate(ThingDef def) 
                     {
                         CompProperties_AmmoUser props = def.GetCompProperties<CompProperties_AmmoUser>();
-                        return props != null && props.ammoSet.ammoTypes.Any(x => x.ammo == this);
+                        if(props?.ammoSet?.ammoTypes != null)
+                        {
+                            return props.ammoSet.ammoTypes.Any(x => x.ammo == this);
+                        }
+                        return false;
                     });
                 }
                 return users;
@@ -41,7 +45,7 @@ namespace CombatExtended
             get
             {
                 if (ammoSetDefs == null)
-                    ammoSetDefs = users.Select(x => x.GetCompProperties<CompProperties_AmmoUser>().ammoSet).Distinct().ToList();
+                    ammoSetDefs = Users.Select(x => x.GetCompProperties<CompProperties_AmmoUser>().ammoSet).Distinct().ToList();
 
                 return ammoSetDefs;
             }


### PR DESCRIPTION
I aways get Error report of this:
Exception from long event: System.NullReferenceException: Object reference not set to an instance of an object
  at CombatExtended.AmmoDef.<get_Users>b__9_0 (Verse.ThingDef def) [0x00000] in <filename unknown>:0 
  at System.Collections.Generic.List`1[Verse.ThingDef].FindAllStackBits (System.Predicate`1 match) [0x00000] in <filename unknown>:0 
  at System.Collections.Generic.List`1[Verse.ThingDef].FindAll (System.Predicate`1 match) [0x00000] in <filename unknown>:0 
  at CombatExtended.AmmoDef.get_Users () [0x00000] in <filename unknown>:0 
  at CombatExtended.AmmoDef.AddDescriptionParts () [0x00000] in <filename unknown>:0 
  at CombatExtended.AmmoInjector.InjectAmmos () [0x00000] in <filename unknown>:0 
  at CombatExtended.AmmoInjector.Inject () [0x00000] in <filename unknown>:0 
  at Verse.LongEventHandler.UpdateCurrentSynchronousEvent (System.Boolean& sceneChanged) [0x00000] in <filename unknown>:0 
Verse.Log:Error(String, Boolean)
Verse.LongEventHandler:UpdateCurrentSynchronousEvent(Boolean&)
Verse.LongEventHandler:LongEventsUpdate_Patch3(Boolean&)
Verse.Root:Update_Patch1(Object)
Verse.Root_Entry:Update()