### PR TITLE
Set selectedAmmo to correct value on spawned pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -486,6 +486,7 @@ namespace CombatExtended
             if (newAmmo != null)
             {
                 currentAmmoInt = newAmmo;
+                selectedAmmo = newAmmo;
             }
             curMagCountInt = Props.magazineSize;
         }


### PR DESCRIPTION
Without this change, the ammo gizmo displays the default ammo on spawned pawns.