### PR TITLE
Fix #937 (loaded ammo has weight/bulk update properly)

### DIFF
--- a/Defs/Stats/Stats_Basics_Inventory.xml
+++ b/Defs/Stats/Stats_Basics_Inventory.xml
@@ -10,6 +10,9 @@
     <minValue>0.001</minValue>
     <toStringStyle>FloatTwo</toStringStyle>
     <displayPriorityInCategory>10</displayPriorityInCategory>
+	<parts>
+		<li Class="CombatExtended.StatPart_LoadedAmmo"/>
+	</parts>
   </StatDef>
   
   <StatDef>

--- a/Languages/English/Keyed/BulkAndWeight.xml
+++ b/Languages/English/Keyed/BulkAndWeight.xml
@@ -38,6 +38,6 @@
 	<CE_AddAmmoFor>Add ammo for {0}</CE_AddAmmoFor>
 	<CE_DropExcess>Drop excess</CE_DropExcess>
 	<CE_PickupMissingAndDropExcess>Pickup missing and drop excess</CE_PickupMissingAndDropExcess>
-
+	<CE_StatsReport_LoadedAmmo>Loaded ammunition</CE_StatsReport_LoadedAmmo>
 
 </LanguageData>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -17,6 +17,13 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName = "Mass"]/parts</xpath>
+		<value>
+			<li Class="CombatExtended.StatPart_LoadedAmmo"/>
+		</value>
+	</Operation>
+
 	<!-- ========== Apparel ========== -->
 
 	<!-- Armor Cap -->

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -179,6 +179,7 @@
     <Compile Include="CombatExtended\Projectiles\Projectile_FireTrail.cs" />
     <Compile Include="CombatExtended\SightUtility.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_AmmoConsumedPerShotCount.cs" />
+    <Compile Include="CombatExtended\StatParts\StatPart_LoadedAmmo.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_ArmorCoverage.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_BodyPartDensity.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_BodyPartKPA.cs" />

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -41,6 +41,14 @@ namespace CombatExtended
             {
                 return curMagCountInt;
             }
+            set
+            {
+                if (curMagCountInt != value && value >= 0)
+                {
+                    curMagCountInt = value;
+                    if (CompInventory != null) CompInventory.UpdateInventory();     //Must be positioned after curMagCountInt is updated, because it relies on that value
+                }
+            }
         }
         public CompEquippable CompEquippable
         {
@@ -262,11 +270,11 @@ namespace CombatExtended
             // If magazine is empty, return false
             if (curMagCountInt <= 0)
             {
-                curMagCountInt = 0;
+                CurMagCount = 0;
                 return false;
             }
             // Reduce ammo count and update inventory
-            curMagCountInt = (curMagCountInt - ammoConsumedPerShot < 0) ? 0 : curMagCountInt - ammoConsumedPerShot;
+            CurMagCount = (curMagCountInt - ammoConsumedPerShot < 0) ? 0 : curMagCountInt - ammoConsumedPerShot;
 
 
             /*if (curMagCountInt - ammoConsumedPerShot < 0)
@@ -279,11 +287,7 @@ namespace CombatExtended
 
 
             // Original: curMagCountInt--;
-
-            if (CompInventory != null)
-            {
-                CompInventory.UpdateInventory();
-            }
+            
             if (curMagCountInt < 0) TryStartReload();
             return true;
         }
@@ -398,7 +402,7 @@ namespace CombatExtended
             }
 
             // don't forget to set the clip to empty...
-            curMagCountInt = 0;
+            CurMagCount = 0;
 
             return true;
         }
@@ -466,7 +470,6 @@ namespace CombatExtended
                         newMagCount = Props.magazineSize;
                         ammoThing.stackCount -= Props.magazineSize;
                     }
-                    if (CompInventory != null) CompInventory.UpdateInventory();
                 }
 
                 // If there's less ammo in inventory than the weapon can hold, or if there's only one bullet left if reloading one at a time
@@ -487,7 +490,7 @@ namespace CombatExtended
             {
                 newMagCount = (Props.reloadOneAtATime) ? (curMagCountInt + 1) : Props.magazineSize;
             }
-            curMagCountInt = newMagCount;
+            CurMagCount = newMagCount;
             if (turret != null) turret.isReloading = false;
             if (parent.def.soundInteract != null) parent.def.soundInteract.PlayOneShot(new TargetInfo(Position, Find.CurrentMap, false));
         }
@@ -503,7 +506,7 @@ namespace CombatExtended
             {
                 currentAmmoInt = newAmmo;
             }
-            curMagCountInt = Props.magazineSize;
+            CurMagCount = Props.magazineSize;
         }
 
         public bool TryFindAmmoInInventory(out Thing ammoThing)

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -281,6 +281,8 @@ namespace CombatExtended
                  weight = eq.GetStatValue(StatDefOf.Mass);
             //old     weight = eq.GetStatValue(CE_StatDefOf.Weight);
                  bulk = eq.GetStatValue(CE_StatDefOf.Bulk);
+
+            /*
             CompAmmoUser comp = eq.TryGetComp<CompAmmoUser>();
             if (comp != null && comp.CurrentAmmo != null)
             {
@@ -288,6 +290,7 @@ namespace CombatExtended
                 //old     weight += comp.currentAmmo.GetStatValueAbstract(CE_StatDefOf.Weight) * comp.curMagCount;
                 bulk += comp.CurrentAmmo.GetStatValueAbstract(CE_StatDefOf.Bulk) * comp.CurMagCount;
             }
+            */
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_AmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_AmmoUser.cs
@@ -16,6 +16,7 @@ namespace CombatExtended
         public bool throwMote = true;
         public AmmoSetDef ammoSet = null;
         public bool spawnUnloaded = false;
+        public float loadedAmmoBulkFactor = 0f;
 
         public CompProperties_AmmoUser()
         {

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_LoadedAmmo.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_LoadedAmmo.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using Verse;
+using RimWorld;
+
+namespace CombatExtended
+{
+    public class StatPart_LoadedAmmo : StatPart
+    {
+        public override void TransformValue(StatRequest req, ref float val)
+        {
+            if (TryGetValue(req, out float num))
+                val += num;
+        }
+
+        public override string ExplanationPart(StatRequest req)
+        {
+            return TryGetValue(req, out float num)
+                ? "CE_StatsReport_LoadedAmmo".Translate() + ": " + parentStat.ValueToString(num)
+                : null;
+        }
+
+        public bool TryGetValue(StatRequest req, out float num)
+        {
+            num = 0f;
+            if (req.HasThing)
+            {
+                var ammoUser = req.Thing.TryGetComp<CompAmmoUser>();
+                if (ammoUser != null && ammoUser.CurrentAmmo != null)
+                {
+                    num = ammoUser.CurrentAmmo.GetStatValueAbstract(parentStat) * ammoUser.CurMagCount;
+
+                    if (parentStat == CE_StatDefOf.Bulk)
+                        num *= ammoUser.Props.loadedAmmoBulkFactor;
+                }
+            }
+            return num != 0f;
+        }
+    }
+}


### PR DESCRIPTION
- CE_StatsReport_LoadedAmmo added to language keys (needs translation)
- Stats.xml patched to add CombatExtended.StatPart_LoadedAmmo to Mass stat
- Added file StatPart_LoadedAmmo
- CompAmmoUser now immediately calls UpdateInventory WHENEVER CurMagCount is changed, as it should be
- CompInventory stopped looking at loaded ammo for weight/bulk
- StatPart_LoadedAmmo was added, which does everything previously done in CompInventory, but which is common in current RimWorld versions
- Bulk StatDef now uses StatPart_LoadedAmmo
- AmmoUser CompProperties include a loadedAmmoBulkFactor with default value 0f. This allows RPG-7 and similar weapons to have a higher bulkiness (volume) when loaded.
- StatPart_LoadedAmmo multiplies by loadedAmmoBulkFactor when parentStat is Bulk