### PR TITLE
Fix for #1038 (generateAllowChance instead of generateCommonality)

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -158,8 +158,8 @@ namespace CombatExtended
                 return;
             }
             // Determine ammo
-            IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
-            AmmoDef ammoToLoad = availableAmmo.RandomElementByWeight(a => a.generateCommonality);
+            IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && a.ammo.generateAllowChance > 0f).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
+            AmmoDef ammoToLoad = availableAmmo.RandomElementByWeight(a => a.generateAllowChance);
             compAmmo.ResetAmmoCount(ammoToLoad);
         }
 


### PR DESCRIPTION
- 17 months ago, during RW version change, the code in the method was changed to generateCommonality from a completely different tag which doesn't exist anymore
- generateAllowChance is commonly used to prevent things from being generated, while generateCommonality is not for preventing, just for weighting
- All CE XML uses generateAllowChance, not generateCommonality
- Therefore, this code change is necessary