### PR TITLE
Update Xenn patches

### DIFF
--- a/Patches/Xenn/ThingDefs_Misc/Xenn_Ammo.xml
+++ b/Patches/Xenn/ThingDefs_Misc/Xenn_Ammo.xml
@@ -1,0 +1,245 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Xenn Race</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<ThingCategoryDef>
+						<defName>AmmoXennCell</defName>
+						<label>Xenn Fuel Cell</label>
+						<parent>AmmoAdvanced</parent>
+						<iconPath>UI/Icons/ThingCategories/CaliberFuel</iconPath>
+					</ThingCategoryDef>
+
+					<!-- ==================== AmmoSet ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_XennFuel</defName>
+						<label>Xenn Fuel Cell</label>
+						<ammoTypes>
+							<Ammo_Xenn_Hot>Bullet_Xenn_Hot</Ammo_Xenn_Hot>
+							<Ammo_Xenn_Cold>Bullet_Xenn_Cold</Ammo_Xenn_Cold>
+							<Ammo_Xenn_Foam>Bullet_Xenn_Foam</Ammo_Xenn_Foam>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" Name="XennCellBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+						<description>Container holding fuel for Xenn weaponry.</description>
+						<statBases>
+							<Mass>0.3</Mass>
+							<Bulk>0.2</Bulk>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting</li>
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoXennCell</li>
+						</thingCategories>
+						<stackLimit>75</stackLimit>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="XennCellBase">
+						<defName>Ammo_Xenn_Hot</defName>
+						<label>Xenn Plasma Cell</label>
+						<graphicData>
+							<texPath>Things/Ammo/FuelCell/Incendiary</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+						</graphicData>
+						<statBases>
+							<MarketValue>1.52</MarketValue>
+						</statBases>
+						<ammoClass>IncendiaryFuel</ammoClass>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="XennCellBase">
+						<defName>Ammo_Xenn_Cold</defName>
+						<label>Xenn Cryogenic Cell</label>
+						<graphicData>
+							<texPath>Things/Ammo/FuelCell/Thermobaric</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+						</graphicData>
+						<statBases>
+							<MarketValue>2.16</MarketValue>
+						</statBases>
+						<ammoClass>ThermobaricFuel</ammoClass>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="XennCellBase">
+						<defName>Ammo_Xenn_Foam</defName>
+						<label>Xenn Firefoam Cell</label>
+						<graphicData>
+							<texPath>Things/Ammo/FuelCell/Foam</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+						</graphicData>
+						<statBases>
+							<MarketValue>0.61</MarketValue>
+						</statBases>
+						<ammoClass>FoamFuel</ammoClass>
+						<generateAllowChance>0</generateAllowChance>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" Name="BaseXennBullet" ParentName="BaseBullet" Abstract="true">
+						<graphicData>
+							<texPath>Things/Projectile/InfernoCannonShot</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+							<shaderType>TransparentPostLight</shaderType>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>80</speed>
+							<dropsCasings>true</dropsCasings>
+							<flyOverhead>false</flyOverhead>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseXennBullet">
+						<defName>Bullet_Xenn_Hot</defName>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<label>incendiary bolt</label>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>PrometheumFlame</damageDef>
+							<damageAmountBase>10</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseXennBullet">
+						<defName>Bullet_Xenn_Cold</defName>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<label>freezer bolt</label>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<explosionRadius>0.75</explosionRadius>
+							<damageDef>Frostbite</damageDef>
+							<damageAmountBase>15</damageAmountBase>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseXennBullet">
+						<defName>Bullet_Xenn_Foam</defName>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<label>foam bolt</label>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Extinguish</damageDef>
+							<damageAmountBase>50</damageAmountBase>
+							<explosionRadius>1</explosionRadius>
+							<postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
+							<preExplosionSpawnChance>1</preExplosionSpawnChance>
+						</projectile>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_Xenn_Hot</defName>
+						<label>make Xenn Plasma Cells x50</label>
+						<description>Craft 50 Xenn plasma cells.</description>
+						<jobString>Making Xenn Plasma cells.</jobString>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Prometheum</li>
+									</thingDefs>
+								</filter>
+								<count>5</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Prometheum</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Xenn_Hot>50</Ammo_Xenn_Hot>
+						</products>
+					</RecipeDef>
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_Xenn_Cold</defName>
+						<label>make Xenn Cryo Cell x50</label>
+						<description>Craft 50 Xenn cryo cells.</description>
+						<jobString>Making Xenn cells.</jobString>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>12</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Xenn_Cold>50</Ammo_Xenn_Cold>
+						</products>
+					</RecipeDef>
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_Xenn_Foam</defName>
+						<label>make Xenn foam cell x50</label>
+						<description>Craft 50 Xenn foam cells.</description>
+						<jobString>Making Xenn foam cells.</jobString>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<categories>
+										<li>MeatRaw</li>
+									</categories>
+								</filter>
+								<count>2</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+							<categories>
+								<li>MeatRaw</li>
+							</categories>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Xenn_Foam>50</Ammo_Xenn_Foam>
+						</products>
+					</RecipeDef>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>

--- a/Patches/Xenn/ThingDefs_Misc/Xenn_Weps.xml
+++ b/Patches/Xenn/ThingDefs_Misc/Xenn_Weps.xml
@@ -54,33 +54,30 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>9</power>
-							<cooldownTime>1.8</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetration>0.11</armorPenetration>
+							<power>8</power>
+							<cooldownTime>1.79</cooldownTime>
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>10</power>
-							<cooldownTime>1.9</cooldownTime>
-							<armorPenetration>0.118</armorPenetration>
+							<power>5</power>
+							<cooldownTime>3.02</cooldownTime>
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
-							<power>10</power>
-							<cooldownTime>1.9</cooldownTime>
-							<armorPenetration>0.086</armorPenetration>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
 							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>
@@ -133,33 +130,30 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>9</power>
-							<cooldownTime>1.8</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetration>0.11</armorPenetration>
+							<power>8</power>
+							<cooldownTime>1.79</cooldownTime>
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>10</power>
-							<cooldownTime>1.9</cooldownTime>
-							<armorPenetration>0.118</armorPenetration>
+							<power>5</power>
+							<cooldownTime>3.02</cooldownTime>
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
-							<power>10</power>
-							<cooldownTime>1.9</cooldownTime>
-							<armorPenetration>0.086</armorPenetration>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
 							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Xenn/ThingDefs_Misc/Xenn_Weps.xml
+++ b/Patches/Xenn/ThingDefs_Misc/Xenn_Weps.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-  <Operation Class="PatchOperationSequence">
-    <success>Always</success>
-    <operations>
-      <li Class="CombatExtended.PatchOperationFindMod">
-        <modName>Xenn Race</modName>
-      </li>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Xenn Race</modName>
+			</li>
 
-      <!-- Xenn Burn Cannon -->
-      <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-        <defName>XennBurnCannon</defName>
+			<!-- Xenn Burn Cannon -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>XennBurnCannon</defName>
 				<statBases>
 					<Bulk>8.5</Bulk>
 					<Mass>4.1</Mass>
@@ -55,9 +55,10 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>barrel</label>
@@ -65,9 +66,9 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>5</power>
-							<cooldownTime>3.02</cooldownTime>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>muzzle</label>
@@ -76,17 +77,17 @@
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.55</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
 			</li>
-	  
-	  <!-- Xenn Frost Cannon -->
-	  <!-- Gonna just be the firegun for now cus ill need to make a good ammo 4 it lol heart -->
-      <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-        <defName>XennFrostCannon</defName>
+
+			<!-- Xenn Frost Cannon -->
+			<!-- Gonna just be the firegun for now cus ill need to make a good ammo 4 it lol heart -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>XennFrostCannon</defName>
 				<statBases>
 					<Bulk>8.5</Bulk>
 					<Mass>4.1</Mass>
@@ -131,9 +132,10 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>barrel</label>
@@ -141,9 +143,9 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>5</power>
-							<cooldownTime>3.02</cooldownTime>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>muzzle</label>
@@ -152,14 +154,14 @@
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.55</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
 			</li>
-      <!-- etc.. -->
-    </operations>
-  </Operation>
+			<!-- etc.. -->
+		</operations>
+	</Operation>
 
 </Patch>

--- a/Patches/Xenn/ThingDefs_Races/Race_Xenn.xml
+++ b/Patches/Xenn/ThingDefs_Races/Race_Xenn.xml
@@ -4,121 +4,125 @@
 	<Operation Class="PatchOperationSequence">
 		<success>Always</success>
 		<operations>
-	<!-- ========== Look for Fido ========== -->
-	<li Class="CombatExtended.PatchOperationFindMod">
+			<!-- ========== Look for Fido ========== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
 				<modName>Xenn Race</modName>
-	</li>
-	<!-- ========== Found Fido ========== -->
-	
-	<!-- ========== Turn our dog boys into dog *boys* ========== -->
-	<!-- ========== To be human is to be a tall brick ========== -->
-	<li Class="PatchOperationAddModExtension">
-	<!-- === Note to future furball compatibility nerds: 		=== -->
-	<!-- === Paste the defName of your horrible alien there   |	=== -->
-	<!-- === 												  V	=== -->
-		<xpath>*/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>Humanoid</bodyShape>
 			</li>
-		</value>
-	</li>
+			<!-- ========== Found Fido ========== -->
 
-	<!-- ========== Gives Gun Gizmos to Xenn HUD thing ========== -->
-	<!-- ========== Also Makes Em Suppressable		   ========== -->
-	
-	<li Class="PatchOperationAdd">
-	<!-- === Shouldn't need to change this at all		  === -->
-	<!-- === Unless you changed the name of your BaseXennPawn === -->
-	<!-- === In which case change "BaseXennPawn" to that name === -->
-		<xpath>*/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
-		<value>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
+			<!-- ========== Turn our dog boys into dog *boys* ========== -->
+			<!-- ========== To be human is to be a tall brick ========== -->
+			<li Class="PatchOperationAddModExtension">
+				<!-- === Note to future furball compatibility nerds: 		=== -->
+				<!-- === Paste the defName of your horrible alien there   |	=== -->
+				<!-- === 												  V	=== -->
+				<xpath>*/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
 			</li>
-			<li Class="CombatExtended.CompProperties_Suppressable" />
-		</value>
-	</li>
-	
-	<!-- === Patch Xenn default melee attacks === -->
-	<!-- === For the most part, it adds the CE melee handler thing 	=== -->
-	<!-- === And also defines armor penetration, which allows them	=== -->
-	<!-- === to actually do damage.									=== -->
+
+			<!-- ========== Gives Gun Gizmos to Xenn HUD thing ========== -->
+			<!-- ========== Also Makes Em Suppressable		   ========== -->
+
 			<li Class="PatchOperationAdd">
-			<xpath>*/AlienRace.ThingDef_AlienRace[defName = "Alien_Xenn"]/statBases</xpath>
-			<value>
-			<AimingAccuracy>1</AimingAccuracy>
-			<MeleeDodgeChance>1</MeleeDodgeChance>
-			<MeleeCritChance>1.15</MeleeCritChance>
-			<MeleeParryChance>1</MeleeParryChance>
-			<ReloadSpeed>1</ReloadSpeed>
-			<Suppressability>1</Suppressability>
-			</value>
+				<!-- === Shouldn't need to change this at all		  === -->
+				<!-- === Unless you changed the name of your BaseXennPawn === -->
+				<!-- === In which case change "BaseXennPawn" to that name === -->
+				<xpath>*/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<!-- === Patch Xenn default melee attacks === -->
+			<!-- === For the most part, it adds the CE melee handler thing 	=== -->
+			<!-- === And also defines armor penetration, which allows them	=== -->
+			<!-- === to actually do damage.									=== -->
+			<li Class="PatchOperationAdd">
+				<xpath>*/AlienRace.ThingDef_AlienRace[defName = "Alien_Xenn"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.15</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<ReloadSpeed>1</ReloadSpeed>
+					<Suppressability>1</Suppressability>
+				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>*/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]/tools</xpath>
-			<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-				<label>left claws</label>
-				<capacities>
-					<li>Scratch</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.3</cooldownTime>
-				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-				<armorPenetration>0.12</armorPenetration>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-				<label>right claws</label>
-				<capacities>
-					<li>Scratch</li>
-				</capacities>
-				<power>8</power>
-				<cooldownTime>1.3</cooldownTime>
-				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-				<armorPenetration>0.12</armorPenetration>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-				<label>teeth</label>
-				<capacities>
-					<li>Bite</li>
-				</capacities>
-				<power>10</power>
-				<cooldownTime>1.6</cooldownTime>
-				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-				<armorPenetration>0.16</armorPenetration>
-				</li>
-			</tools>
-			</value>
+				<xpath>*/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.37</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.02</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.923</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
 			</li>
-	<!-- ===================================== -->
-	<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
-	<!-- ===================================== -->
-	<!-- === Adds In Inspector Tabs 	   === -->
-	<!-- === Inventory and all that jazz   === -->
-	<!-- === Again, no need to change 'em  === -->
-	<!-- === Unless you changed it         === -->
-	<!-- === then change 'em			   === -->
-	
-	<li Class="PatchOperationReplace">
-		<xpath>*/ThingDef[@Name="BaseXennPawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-		<value>
-			<li>CombatExtended.ITab_Inventory</li>
-		</value>
-	</li>
+			<!-- ===================================== -->
+			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
+			<!-- ===================================== -->
+			<!-- === Adds In Inspector Tabs 	   === -->
+			<!-- === Inventory and all that jazz   === -->
+			<!-- === Again, no need to change 'em  === -->
+			<!-- === Unless you changed it         === -->
+			<!-- === then change 'em			   === -->
 
-	<li Class="PatchOperationAdd">
-	
-		<xpath>*/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
-		<value>
-			<li Class="CombatExtended.CompProperties_Inventory" />
-		</value>
-	</li>
+			<li Class="PatchOperationReplace">
+				<xpath>*/ThingDef[@Name="BaseXennPawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<value>
+					<li>CombatExtended.ITab_Inventory</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+
+				<xpath>*/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Inventory" />
+				</value>
+			</li>
 		</operations>
 	</Operation>
-	
+
 	<!-- === Congratulations! Your alien is Combat Ready!	 === -->
 	<!-- === If your alien comes with extra guns and gear,	 === -->
 	<!-- === Congratulations! You're not even close to done! === -->

--- a/Patches/Xenn/ThingDefs_Races/Race_Xenn.xml
+++ b/Patches/Xenn/ThingDefs_Races/Race_Xenn.xml
@@ -16,7 +16,7 @@
 				<!-- === Note to future furball compatibility nerds: 		=== -->
 				<!-- === Paste the defName of your horrible alien there   |	=== -->
 				<!-- === 												  V	=== -->
-				<xpath>*/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]</xpath>
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Humanoid</bodyShape>
@@ -31,7 +31,7 @@
 				<!-- === Shouldn't need to change this at all		  === -->
 				<!-- === Unless you changed the name of your BaseXennPawn === -->
 				<!-- === In which case change "BaseXennPawn" to that name === -->
-				<xpath>*/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
+				<xpath>Defs/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
 				<value>
 					<li>
 						<compClass>CombatExtended.CompPawnGizmo</compClass>
@@ -45,7 +45,7 @@
 			<!-- === And also defines armor penetration, which allows them	=== -->
 			<!-- === to actually do damage.									=== -->
 			<li Class="PatchOperationAdd">
-				<xpath>*/AlienRace.ThingDef_AlienRace[defName = "Alien_Xenn"]/statBases</xpath>
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Alien_Xenn"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
@@ -57,7 +57,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>*/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]/tools</xpath>
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Xenn"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -107,7 +107,7 @@
 			<!-- === then change 'em			   === -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>*/ThingDef[@Name="BaseXennPawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<xpath>Defs/ThingDef[@Name="BaseXennPawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
 				<value>
 					<li>CombatExtended.ITab_Inventory</li>
 				</value>
@@ -115,7 +115,7 @@
 
 			<li Class="PatchOperationAdd">
 
-				<xpath>*/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
+				<xpath>Defs/ThingDef[@Name="BaseXennPawn"]/comps</xpath>
 				<value>
 					<li Class="CombatExtended.CompProperties_Inventory" />
 				</value>


### PR DESCRIPTION
* Reimplement Xenn ammo as conditional patches
* Update Xenn weapon melee tools
* Update Xenn race melee tools

Note - further revision of the Xenn ammo will be done post-CE 2.0:
* The two weapons are meant to fire different ammo (one hot, one cold), rather than sharing one universal ammoset
* The previous patch author incorrectly described a freezing ammo cartridge as thermobaric 