### PR TITLE
Update DMGT pack patches

### DIFF
--- a/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Defensive_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Defensive_Turrets.xml
@@ -12,18 +12,18 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_DP28MG</defName>
 				<statBases>
-					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.05</ShotSpread>
 					<SwayFactor>1.19</SwayFactor>
-					<Bulk>8.00</Bulk>
+					<Bulk>13.70</Bulk>
 				</statBases>
 				<Properties>
 					<recoilAmount>0.71</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-					<warmupTime>1.25</warmupTime>
+					<warmupTime>1.3</warmupTime>
 					<range>75</range>
 					<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 					<burstShotCount>10</burstShotCount>
@@ -33,7 +33,6 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>9</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>47</magazineSize>
@@ -43,11 +42,18 @@
 				<FireModes>
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>SuppressFire</aiAimMode>
-					<aimedBurstShotCount>10</aimedBurstShotCount>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
 				</FireModes>
 				<weaponTags>
 					<li>TurretGun</li>
 				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_DP28MG"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>75</specialDisplayRadius>
+				</value>
 			</li>
 
 			<!-- ========== Mounted M2HB Turret ========== -->
@@ -56,7 +62,7 @@
 				<defName>Gun_M2HB</defName>
 				<statBases>
 					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.01</ShotSpread>
 					<SwayFactor>1.59</SwayFactor>
 					<Bulk>18.54</Bulk>
@@ -66,8 +72,8 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>126</range>
+					<warmupTime>1.3</warmupTime>
+					<range>86</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 					<burstShotCount>10</burstShotCount>
 					<soundCast>ShotM2</soundCast>
@@ -76,7 +82,6 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>13</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>100</magazineSize>
@@ -93,33 +98,39 @@
 				</weaponTags>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_M2HB"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
 			<!-- ========== Mounted Twin M2HB Turret ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_M2HBT</defName>
 				<statBases>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
-					<ShotSpread>0.02</ShotSpread>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
 					<SwayFactor>2.13</SwayFactor>
-					<Bulk>37.08</Bulk>
+					<Bulk>37.08</Bulk> <!-- Twice the bulk of a single M2HB -->
 				</statBases>
 				<Properties>
 					<recoilAmount>0.83</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>126</range>
+					<warmupTime>1.3</warmupTime>
+					<range>86</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-					<burstShotCount>20</burstShotCount>
+					<burstShotCount>20</burstShotCount> <!-- Dual M2HBs firing side-by-side -->
 					<soundCast>ShotM2</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>13</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>200</magazineSize>
@@ -129,11 +140,18 @@
 				<FireModes>
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>SuppressFire</aiAimMode>
-					<aimedBurstShotCount>10</aimedBurstShotCount>
+					<aimedBurstShotCount>10</aimedBurstShotCount> <!-- Dual M2HBs firing side-by-side -->
 				</FireModes>
 				<weaponTags>
 					<li>TurretGun</li>
 				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_M2HBT"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
 			</li>
 
 			<!-- ========== Mounted M134 Turret ========== -->
@@ -141,8 +159,8 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_M134MG</defName>
 				<statBases>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.06</ShotSpread>
 					<SwayFactor>1.23</SwayFactor>
 					<Bulk>8.02</Bulk>
@@ -152,7 +170,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>2.3</warmupTime>
 					<range>86</range>
 					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 					<burstShotCount>100</burstShotCount>
@@ -162,17 +180,16 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>10</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>500</magazineSize>
-					<reloadTime>7.8</reloadTime>
+					<reloadTime>9.2</reloadTime>
 					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>SuppressFire</aiAimMode>
-					<aimedBurstShotCount>200</aimedBurstShotCount>
+					<aimedBurstShotCount>50</aimedBurstShotCount>
 					<noSnapshot>true</noSnapshot>
 					<noSingleShot>true</noSingleShot>
 				</FireModes>
@@ -181,25 +198,33 @@
 				</weaponTags>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_M134MG"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
 			<!-- ========== Mounted Mk 19 Turret ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_Mk19MGL</defName>
 				<statBases>
 					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.09</ShotSpread>
 					<SwayFactor>1.49</SwayFactor>
-					<Bulk>12.9</Bulk>
+					<Bulk>12.90</Bulk>
 				</statBases>
 				<Properties>
 					<recoilAmount>1.67</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>112</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<warmupTime>1.3</warmupTime>
+					<range>78</range>
+					<minRange>6</minRange>
+					<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
 					<burstShotCount>6</burstShotCount>
 					<soundCast>InfernoCannon_Fire</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
@@ -207,7 +232,6 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>16</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>48</magazineSize>
@@ -222,6 +246,13 @@
 				<weaponTags>
 					<li>TurretGun</li>
 				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_Mk19MGL"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>78</specialDisplayRadius>
+				</value>
 			</li>
 
 			<!-- ========== Work To Build ========== -->
@@ -319,20 +350,8 @@
 					defName="Turret_Mk19MGL"
 				]/statBases</xpath>
 				<value>
-					<AimingAccuracy>0.5</AimingAccuracy>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-					defName="Turret_DP28MG" or
-					defName="Turret_M2HB" or
-					defName="Turret_M2HBT" or
-					defName="Turret_M134MG" or
-					defName="Turret_Mk19MGL"
-				]/statBases/ShootingAccuracy</xpath>
-				<value>
-					<ShootingAccuracy>1</ShootingAccuracy>
+					<AimingAccuracy>0.9</AimingAccuracy>
+					<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
 				</value>
 			</li>
 

--- a/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Defensive_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Defensive_Turrets.xml
@@ -33,6 +33,7 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>47</magazineSize>
@@ -82,6 +83,7 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>13</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>100</magazineSize>
@@ -131,6 +133,7 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>13</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>200</magazineSize>
@@ -180,6 +183,7 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>10</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>500</magazineSize>
@@ -232,6 +236,7 @@
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
 					<muzzleFlashScale>16</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>48</magazineSize>

--- a/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Sentry_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Sentry_Turrets.xml
@@ -13,9 +13,9 @@
 				<defName>Gun_M2HBs</defName>
 				<statBases>
 					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.01</ShotSpread>
-					<SwayFactor>1.09</SwayFactor>
+					<SwayFactor>1.65</SwayFactor>
 					<Bulk>18.54</Bulk>
 				</statBases>
 				<Properties>
@@ -23,14 +23,13 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>126</range>
+					<warmupTime>1.3</warmupTime>
+					<range>86</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 					<burstShotCount>10</burstShotCount>
 					<soundCast>ShotM2</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>13</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>100</magazineSize>
@@ -49,15 +48,22 @@
 				</weaponTags>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_M2HBs"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
 			<!-- ========== M134 Sentry Gun ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_M134MGs</defName>
 				<statBases>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.06</ShotSpread>
-					<SwayFactor>0.73</SwayFactor>
+					<SwayFactor>1.31</SwayFactor>
 					<Bulk>8.02</Bulk>
 				</statBases>
 				<Properties>
@@ -65,24 +71,23 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>2.3</warmupTime>
 					<range>86</range>
 					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 					<burstShotCount>100</burstShotCount>
 					<soundCast>Shot_Minigun</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>10</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>500</magazineSize>
-					<reloadTime>7.8</reloadTime>
+					<reloadTime>9.2</reloadTime>
 					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>AimedShot</aiAimMode>
-					<aimedBurstShotCount>200</aimedBurstShotCount>
+					<aimedBurstShotCount>50</aimedBurstShotCount>
 					<noSnapshot>true</noSnapshot>
 					<noSingleShot>true</noSingleShot>
 				</FireModes>
@@ -91,30 +96,37 @@
 				</weaponTags>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_M134MGs"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
 			<!-- ========== Mk 19 Sentry Gun ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>Gun_Mk19MGLs</defName>
 				<statBases>
 					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.09</ShotSpread>
-					<SwayFactor>0.99</SwayFactor>
-					<Bulk>12.9</Bulk>
+					<SwayFactor>1.55</SwayFactor>
+					<Bulk>12.90</Bulk>
 				</statBases>
 				<Properties>
 					<recoilAmount>1.58</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
-					<range>112</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<warmupTime>1.3</warmupTime>
+					<range>78</range>
+					<minRange>6</minRange>
+					<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
 					<burstShotCount>6</burstShotCount>
 					<soundCast>InfernoCannon_Fire</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>16</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>48</magazineSize>
@@ -131,6 +143,13 @@
 				<weaponTags>
 					<li>TurretGun</li>
 				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_Mk19MGLs"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>78</specialDisplayRadius>
+				</value>
 			</li>
 
 			<!-- ========== Work To Build ========== -->
@@ -205,17 +224,7 @@
 				]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1.0</AimingAccuracy>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-					defName="Turret_M2HBs" or
-					defName="Turret_M134MGs" or
-					defName="Turret_Mk19MGLs"
-				]/statBases/ShootingAccuracy</xpath>
-				<value>
-					<ShootingAccuracy>1</ShootingAccuracy>
+					<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
 				</value>
 			</li>
 

--- a/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Sentry_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/ThingDefs/DMGT_Sentry_Turrets.xml
@@ -30,6 +30,7 @@
 					<soundCast>ShotM2</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>13</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>100</magazineSize>
@@ -78,6 +79,7 @@
 					<soundCast>Shot_Minigun</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>10</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>500</magazineSize>
@@ -127,6 +129,7 @@
 					<soundCast>InfernoCannon_Fire</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>16</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>48</magazineSize>


### PR DESCRIPTION
Patches brought over as part of the FastTrack merger

* Turret weapon stats re-calculated using the [CE:FT Gun Stats spreadsheet](https://docs.google.com/spreadsheets/d/1Z9ZBnwRQWCKQm18O4I9ja4mFwLVChkNNfam2ZeQTTa0/edit#gid=1573763037)
* Reduced a number of turret ranges to more reasonable values
* Fixed incorrect turret range display radius
