### PR TITLE
Update Android Tiers patches

### DIFF
--- a/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
+++ b/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
@@ -12,7 +12,7 @@
 					<xpath>Defs</xpath>
 					<value>
 
-						<!-- There is only one type of Mastiff shell for CE:FT, no subcategory for variants required -->
+						<!-- There is only one type of Mastiff shell, no subcategory for variants required -->
 
 						<!-- ==================== AmmoSet ========================== -->
 

--- a/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
+++ b/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.0] Android tiers</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- There is only one type of Mastiff shell for CE:FT, no subcategory for variants required -->
+
+						<!-- ==================== AmmoSet ========================== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_MastiffShotgunShell</defName>
+							<label>Mastiff shell</label>
+							<ammoTypes>
+								<Ammo_MastiffShotgunShell>Bullet_MastiffShotgunShell</Ammo_MastiffShotgunShell>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<!-- ==================== Ammo ========================== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" Name="MastiffShotgunShellBase" ParentName="AmmoBase" Abstract="True">
+							<description>Very large caliber buckshot shell designed specifically for the mech-operated Mastiff Shotgun.</description>
+							<statBases>
+								<Mass>2.128</Mass>
+								<Bulk>7.22</Bulk>
+							</statBases>
+							<tradeTags>
+								<li>CE_AutoEnableTrade</li>
+								<li>CE_AutoEnableCrafting_TableMachining</li>
+							</tradeTags>
+							<thingCategories>
+								<li>AmmoAdvanced</li>
+							</thingCategories>
+							<stackLimit>25</stackLimit>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="MastiffShotgunShellBase">
+							<defName>Ammo_MastiffShotgunShell</defName>
+							<label>Mastiff shell (Buck)</label>
+							<graphicData>
+								<texPath>ThirdParty/Android Tiers/MastiffShell</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>9.52</MarketValue>
+							</statBases>
+							<ammoClass>BuckShot</ammoClass>
+						</ThingDef>
+
+						<!-- ================== Projectiles ================== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" Name="BaseMastiffShotgunShell" ParentName="BaseBullet" Abstract="true">
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bullet</damageDef>
+								<speed>107</speed>
+								<dropsCasings>true</dropsCasings>
+								<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseMastiffShotgunShell">
+							<defName>Bullet_MastiffShotgunShell</defName>
+							<label>Mastiff buckshot pellet</label>
+							<graphicData>
+								<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>23</damageAmountBase>
+								<pelletCount>200</pelletCount>
+								<armorPenetrationSharp>5</armorPenetrationSharp>
+								<armorPenetrationBlunt>79.54</armorPenetrationBlunt>
+								<spreadMult>17.8</spreadMult>
+							</projectile>
+						</ThingDef>
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_MastiffShotgunShell</defName>
+							<label>make Mastiff (Buck) shell x5</label>
+							<description>Craft 5 Mastiff (Buck) shells.</description>
+							<jobString>Making Mastiff (Buck) shells.</jobString>
+							<workAmount>2400</workAmount>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>24</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_MastiffShotgunShell>5</Ammo_MastiffShotgunShell>
+							</products>
+						</RecipeDef>
+
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
+++ b/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>[1.0] Android tiers</li>
+			<li>Android tiers</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
@@ -55,17 +56,9 @@
 						</ThingDef>
 
 						<!-- ================== Projectiles ================== -->
-
-						<ThingDef Class="CombatExtended.AmmoDef" Name="BaseMastiffShotgunShell" ParentName="BaseBullet" Abstract="true">
-							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
-								<speed>107</speed>
-								<dropsCasings>true</dropsCasings>
-								<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
-							</projectile>
-						</ThingDef>
-
-						<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseMastiffShotgunShell">
+						
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base12GaugeBullet) -->
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
 							<defName>Bullet_MastiffShotgunShell</defName>
 							<label>Mastiff buckshot pellet</label>
 							<graphicData>
@@ -73,6 +66,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>107</speed>
 								<damageAmountBase>23</damageAmountBase>
 								<pelletCount>200</pelletCount>
 								<armorPenetrationSharp>5</armorPenetrationSharp>

--- a/Patches/Android Tiers/Ammo/X5Pistol.xml
+++ b/Patches/Android Tiers/Ammo/X5Pistol.xml
@@ -12,7 +12,7 @@
 					<xpath>Defs</xpath>
 					<value>
 
-						<!-- There is only one type of Mastiff shell for CE:FT, no subcategory for variants required -->
+						<!-- There is only one type of Mastiff shell, no subcategory for variants required -->
 
 						<!-- ==================== AmmoSet ========================== -->
 
@@ -57,7 +57,7 @@
 
 						<!-- ================== Projectiles ================== -->
 
-						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base12GaugeBullet) -->
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base600NitroExpressBullet) -->
 						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base600NitroExpressBullet">
 							<defName>Bullet_AndroidTiersX5Pistol</defName>
 							<label>X-5 round</label>

--- a/Patches/Android Tiers/Ammo/X5Pistol.xml
+++ b/Patches/Android Tiers/Ammo/X5Pistol.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.0] Android tiers</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- There is only one type of Mastiff shell for CE:FT, no subcategory for variants required -->
+
+						<!-- ==================== AmmoSet ========================== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_AndroidTiersX5Pistol</defName>
+							<label>X-5 cartridge</label>
+							<ammoTypes>
+								<Ammo_AndroidTiersX5Pistol>Bullet_AndroidTiersX5Pistol</Ammo_AndroidTiersX5Pistol>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<!-- ==================== Ammo ========================== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" Name="AndroidTiersX5PistolBase" ParentName="AmmoBase" Abstract="True">
+							<description>Large-caliber handgun round designed specifically for use with the mech-operated X-5 Pistol.</description>
+							<statBases>
+								<Mass>0.138</Mass>
+								<Bulk>0.07</Bulk>
+							</statBases>
+							<tradeTags>
+								<li>CE_AutoEnableTrade</li>
+								<li>CE_AutoEnableCrafting</li>
+							</tradeTags>
+							<thingCategories>
+								<li>AmmoAdvanced</li>
+							</thingCategories>
+							<stackLimit>350</stackLimit>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="AndroidTiersX5PistolBase">
+							<defName>Ammo_AndroidTiersX5Pistol</defName>
+							<label>X-5 cartridge</label>
+							<graphicData>
+								<texPath>ThirdParty/Android Tiers/X5Cartridge</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>0.56</MarketValue>
+							</statBases>
+							<ammoClass>FullMetalJacket</ammoClass>
+						</ThingDef>
+
+						<!-- ================== Projectiles ================== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" Name="BaseAndroidTiersX5Pistol" ParentName="BaseBullet" Abstract="true">
+							<graphicData>
+								<texPath>Things/Projectile/ShellHighExplosive</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>TransparentPostLight</shaderType>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bullet</damageDef>
+								<speed>124</speed>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseAndroidTiersX5Pistol">
+							<defName>Bullet_AndroidTiersX5Pistol</defName>
+							<label>X-5 round</label>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>38</damageAmountBase>
+								<armorPenetrationSharp>11</armorPenetrationSharp>
+								<armorPenetrationBlunt>222.960</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_AndroidTiersX5Pistol</defName>
+							<label>make X-5 cartridge x350</label>
+							<description>Craft 350 X-5 cartridges.</description>
+							<jobString>Making X-5 cartridges.</jobString>
+							<workAmount>9800</workAmount>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>98</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_AndroidTiersX5Pistol>350</Ammo_AndroidTiersX5Pistol>
+							</products>
+						</RecipeDef>
+
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Android Tiers/Ammo/X5Pistol.xml
+++ b/Patches/Android Tiers/Ammo/X5Pistol.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>[1.0] Android tiers</li>
+			<!--<li>Android tiers</li>-->
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
@@ -56,22 +57,17 @@
 
 						<!-- ================== Projectiles ================== -->
 
-						<ThingDef Class="CombatExtended.AmmoDef" Name="BaseAndroidTiersX5Pistol" ParentName="BaseBullet" Abstract="true">
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base12GaugeBullet) -->
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base600NitroExpressBullet">
+							<defName>Bullet_AndroidTiersX5Pistol</defName>
+							<label>X-5 round</label>
 							<graphicData>
 								<texPath>Things/Projectile/ShellHighExplosive</texPath>
 								<graphicClass>Graphic_Single</graphicClass>
 								<shaderType>TransparentPostLight</shaderType>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<damageDef>Bullet</damageDef>
-								<speed>124</speed>
-							</projectile>
-						</ThingDef>
-
-						<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseAndroidTiersX5Pistol">
-							<defName>Bullet_AndroidTiersX5Pistol</defName>
-							<label>X-5 round</label>
-							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>124</speed>
 								<damageAmountBase>38</damageAmountBase>
 								<armorPenetrationSharp>11</armorPenetrationSharp>
 								<armorPenetrationBlunt>222.960</armorPenetrationBlunt>

--- a/Patches/Android Tiers/Ammo/X5Pistol.xml
+++ b/Patches/Android Tiers/Ammo/X5Pistol.xml
@@ -4,7 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>[1.0] Android tiers</li>
-			<!--<li>Android tiers</li>-->
+			<li>Android tiers</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -58,12 +58,18 @@
 						<sidearms>
 							<li>
 								<generateChance>1</generateChance>
-								<sidearmMoney>
-									<min>0</min>
-									<max>1250</max>
-								</sidearmMoney>
+								<magazineCount>
+									<min>2</min>
+									<max>3</max>
+								</magazineCount>
 								<weaponTags>
 									<li>CE_Sidearm_M7Mech</li>
+								</weaponTags>
+							</li>
+							<li>
+								<generateChance>1</generateChance>
+								<weaponTags>
+									<li>CE_Melee_M7Mech</li>
 								</weaponTags>
 							</li>
 						</sidearms>

--- a/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
+++ b/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
@@ -24,7 +24,7 @@
 					<recoilAmount>1.72</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
+					<defaultProjectile>Bullet_40x365mmBofors_AP</defaultProjectile>
 					<warmupTime>1.45</warmupTime>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -38,9 +38,9 @@
 				</Properties>
 				
 				<AmmoUser>
-					<magazineSize>42</magazineSize>
+					<magazineSize>24</magazineSize>
 					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_40x53mmGrenade</ammoSet>
+					<ammoSet>AmmoSet_40x365mmBofors</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aimedBurstShotCount>3</aimedBurstShotCount>
@@ -51,7 +51,10 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mech40MMCannon"]/description</xpath>
 				<value>
-					<description>This modified 40mm Cannon is capable of burst firing grenades in quick succession. Designed for area saturation or anti-mechanoid combat, it is quite the weapon. Originally being the factory standard when producing the M7 Mech, equipped on every unit in production.</description>
+					<!-- Change description, as original one mentions "three 80kg rounds", which is laughably unrealistic 
+					     (For comparison, the real-life 120 mm M829 sabot tank rounds each have a mass of only 22.3 kg, 
+						 so it stands that the smaller 40 mm should have a much lower mass )-->
+					<description>This modified 40mm Cannon is capable of burst firing three 40x365mm Bofors rounds in quick succession. Designed for anti-material or mech on mech combat, it is quite the weapon. Originally being the factory standard when producing the M7 Mech, equipped on every unit in production</description>
 				</value>
 			</li>
 			
@@ -110,7 +113,7 @@
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_AndroidTiersX5Pistol</defaultProjectile>
 					<warmupTime>0.7</warmupTime>
 					<range>55</range>
 					<soundCast>40MMCannon</soundCast>
@@ -123,7 +126,7 @@
 				<AmmoUser>
 					<magazineSize>15</magazineSize>
 					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_145x114mm</ammoSet>
+					<ammoSet>AmmoSet_AndroidTiersX5Pistol</ammoSet>
 				</AmmoUser>
 			</li>
 			
@@ -166,6 +169,15 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MechHandCannon"]/weaponTags</xpath>
+				<value>
+					<weaponTags>
+						<li>CE_Sidearm_M7Mech</li>
+					</weaponTags>
+				</value>
+			</li>
+			
 			<!-- ==========  Mastiff  =========== -->
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -183,34 +195,27 @@
 					<recoilAmount>1.72</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_12GaugeCharged</defaultProjectile>
+					<defaultProjectile>Bullet_MastiffShotgunShell</defaultProjectile>
 					<warmupTime>0.6</warmupTime>
-					<burstShotCount>6</burstShotCount>
+					<burstShotCount>1</burstShotCount>
 					<ticksBetweenBurstShots>0</ticksBetweenBurstShots>
 					<range>25</range>
-					<soundCast>40MMCannon</soundCast>
+					<soundCast>SharpThrower</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>18</muzzleFlashScale>
 					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				
 				<AmmoUser>
-					<magazineSize>72</magazineSize>
-					<reloadTime>4</reloadTime>
-					<ammoSet>AmmoSet_12GaugeCharged</ammoSet>
+					<magazineSize>5</magazineSize>
+					<reloadOneAtATime>true</reloadOneAtATime>
+					<reloadTime>1.75</reloadTime>
+					<ammoSet>AmmoSet_MastiffShotgunShell</ammoSet>
 				</AmmoUser>
 				<FireModes>
-					<aimedBurstShotCount>3</aimedBurstShotCount>
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 				</FireModes>
 				
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="MechMastiffGun"]/description</xpath>
-				<value>
-					<description>A mech shotgun, designed to deliver a heavy punch. This gun cools its firing mechanism constantly, permitting high volume burst fire.</description>
-				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
@@ -282,10 +287,12 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="MeleeWeapon_MechKnife"]/weaponTags</xpath>
 				<value>
-					<li>CE_Sidearm_M7Mech</li>
+					<weaponTags>
+						<li>CE_Melee_M7Mech</li>
+					</weaponTags>
 				</value>
 			</li>
 			

--- a/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
@@ -490,6 +490,10 @@
 					<MeleeCritChance>1.25</MeleeCritChance>
 					<MeleeParryChance>1.25</MeleeParryChance>
 					<SmokeSensitivity>0</SmokeSensitivity>
+					<!-- Increase CarryWeight and CarryBulk so that M7 Mechs can carry primary + secondary weapons plus their respective ammo -->
+					<!-- Values are multipled by 5.2 (for body size) -->
+					<CarryWeight>150</CarryWeight>
+					<CarryBulk>300</CarryBulk>
 				  </value>
 				</li>
 				<!--150% Power Armor : brings it more in line with centipede armor rating ratio-->


### PR DESCRIPTION
* Add the following mod-unique ammo:
  * X-5 Pistol cartridge
  * Mastiff Shotgun shell
* Change ammunition for the following Mech weapons:
  * 40mm Cannon now uses 40x365mm Bofors shells
  * X-5 Pistol now uses X-5 Pistol cartridges
  * Mastiff Shotgun now uses Mastiff Shotgun shells
* Adjust M7 Mech loadout so that they spawn with a primary weapon (40mm Cannon or Mastiff Shotgun), a sidearm (X-5 Pistol), a mech combat knife and ammunition for both primary and sidearms
* Adjust M7 Mech CarryBulk and CarryWeight capacity to allow them to carry their (increased) inventory

NOTE: This is WIP - the X-5 Pistol cartridge and Mastiff Shotgun shell are currently not responding well to conditional patching