### PR TITLE
Actually implement CE_Ammo tag

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -23,6 +23,7 @@ namespace CombatExtended
     {
         public static readonly FieldInfo _allRecipesCached = typeof(ThingDef).GetField("allRecipesCached", BindingFlags.Instance | BindingFlags.NonPublic);
 
+        public const string destroyWithAmmoDisabledTag = "CE_Ammo";               // The trade tag which automatically deleted this ammo with the ammo system disabled
         private const string enableTradeTag = "CE_AutoEnableTrade";             // The trade tag which designates ammo defs for being automatically switched to Tradeability.Stockable
         private const string enableCraftingTag = "CE_AutoEnableCrafting";        // The trade tag which designates ammo defs for having their crafting recipes automatically added to the crafting table
         /*
@@ -112,88 +113,94 @@ namespace CombatExtended
 
             foreach (AmmoDef ammoDef in ammoDefs)
             {
-                // Toggle ammo visibility in the debug menu
-                ammoDef.menuHidden = !enabled;
-                ammoDef.destroyOnDrop = !enabled;
-
                 //AFTER CE_Utility.allWeaponDefs is initiated, this sets each ammo to list its users & special effects in its DEF DESCRIPTION rather than its THING DESCRIPTION.
                 //This is because the THING description ISN'T available during crafting - so people can now figure out what's different between ammo types.
                 ammoDef.AddDescriptionParts();
 
-                // Toggle trading
-                var tradingTags = ammoDef.tradeTags.Where(t => t.StartsWith(enableTradeTag));
-                if (tradingTags.Any())
+                if (ammoDef.tradeTags != null)
                 {
-                    var curTag = tradingTags.First();
-
-                    if (curTag == enableTradeTag)
+                    if (ammoDef.tradeTags.Contains(destroyWithAmmoDisabledTag))
                     {
-                        ammoDef.tradeability = enabled ? Tradeability.All : Tradeability.None;
+                        // Toggle ammo visibility in the debug menu
+                        ammoDef.menuHidden = !enabled;
+                        ammoDef.destroyOnDrop = !enabled;
                     }
-                    else
+
+                    // Toggle trading
+                    var tradingTags = ammoDef.tradeTags.Where(t => t.StartsWith(enableTradeTag));
+                    if (tradingTags.Any())
                     {
-                        if (curTag.Length <= enableTradeTag.Length + 1)
+                        var curTag = tradingTags.First();
+
+                        if (curTag == enableTradeTag)
                         {
-                            Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but " + curTag + " is not a valid trading tag, valid formats are: " + enableTradeTag + " and " + enableTradeTag + "_levelOfTradeability");
+                            ammoDef.tradeability = enabled ? Tradeability.All : Tradeability.None;
                         }
                         else
                         {
-                            var tradeabilityName = curTag.Remove(0, enableTradeTag.Length + 1);
+                            if (curTag.Length <= enableTradeTag.Length + 1)
+                            {
+                                Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but " + curTag + " is not a valid trading tag, valid formats are: " + enableTradeTag + " and " + enableTradeTag + "_levelOfTradeability");
+                            }
+                            else
+                            {
+                                var tradeabilityName = curTag.Remove(0, enableTradeTag.Length + 1);
 
-                            ammoDef.tradeability = enabled
-                                ? (Tradeability)Enum.Parse(typeof(Tradeability), tradeabilityName, true)
-                                : Tradeability.None;
+                                ammoDef.tradeability = enabled
+                                    ? (Tradeability)Enum.Parse(typeof(Tradeability), tradeabilityName, true)
+                                    : Tradeability.None;
+                            }
                         }
                     }
-                }
 
-                // Toggle craftability
-                var craftingTags = ammoDef.tradeTags.Where(t => t.StartsWith(enableCraftingTag));
-                if (craftingTags.Any())
-                {
-                    RecipeDef recipe = DefDatabase<RecipeDef>.GetNamed(("Make" + ammoDef.defName), false);
-                    if (recipe == null)
+                    // Toggle craftability
+                    var craftingTags = ammoDef.tradeTags.Where(t => t.StartsWith(enableCraftingTag));
+                    if (craftingTags.Any())
                     {
-                        Log.Error("CE ammo injector found no recipe named Make" + ammoDef.defName);
-                    }
-                    else
-                    {
-                        // Go through all crafting tags and add to the appropriate benches
-                        foreach (string curTag in craftingTags)
+                        RecipeDef recipe = DefDatabase<RecipeDef>.GetNamed(("Make" + ammoDef.defName), false);
+                        if (recipe == null)
                         {
-                            ThingDef bench;
-                            if (curTag == enableCraftingTag)
+                            Log.Error("CE ammo injector found no recipe named Make" + ammoDef.defName);
+                        }
+                        else
+                        {
+                            // Go through all crafting tags and add to the appropriate benches
+                            foreach (string curTag in craftingTags)
                             {
-                                bench = CE_ThingDefOf.AmmoBench;
-                            }
-                            else
-                            {
-                                // Parse tag for bench def
-                                if (curTag.Length <= enableCraftingTag.Length + 1)
+                                ThingDef bench;
+                                if (curTag == enableCraftingTag)
                                 {
-                                    Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but " + curTag + " is not a valid crafting tag, valid formats are: " + enableCraftingTag + " and " + enableCraftingTag + "_defNameOfCraftingBench");
-                                    continue;
+                                    bench = CE_ThingDefOf.AmmoBench;
                                 }
-                                var benchName = curTag.Remove(0, enableCraftingTag.Length + 1);
-                                bench = DefDatabase<ThingDef>.GetNamed(benchName, false);
-                                if (bench == null)
+                                else
                                 {
-                                    Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no crafting bench with defName=" + benchName + " could be found for tag " + curTag);
-                                    continue;
+                                    // Parse tag for bench def
+                                    if (curTag.Length <= enableCraftingTag.Length + 1)
+                                    {
+                                        Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but " + curTag + " is not a valid crafting tag, valid formats are: " + enableCraftingTag + " and " + enableCraftingTag + "_defNameOfCraftingBench");
+                                        continue;
+                                    }
+                                    var benchName = curTag.Remove(0, enableCraftingTag.Length + 1);
+                                    bench = DefDatabase<ThingDef>.GetNamed(benchName, false);
+                                    if (bench == null)
+                                    {
+                                        Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no crafting bench with defName=" + benchName + " could be found for tag " + curTag);
+                                        continue;
+                                    }
                                 }
+                                ToggleRecipeOnBench(recipe, bench);
+                                /*
+                                // Toggle recipe
+                                if (enabled)
+                                {
+                                    recipe.recipeUsers.Add(bench);
+                                }
+                                else
+                                {
+                                    recipe.recipeUsers.RemoveAll(x => x.defName == bench.defName);
+                                }
+                                */
                             }
-                            ToggleRecipeOnBench(recipe, bench);
-                            /*
-                            // Toggle recipe
-                            if (enabled)
-                            {
-                                recipe.recipeUsers.Add(bench);
-                            }
-                            else
-                            {
-                                recipe.recipeUsers.RemoveAll(x => x.defName == bench.defName);
-                            }
-                            */
                         }
                     }
                 }

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -65,10 +65,25 @@ namespace CombatExtended
             }
         }
 
+        int shouldDestroy = -1;
+        public bool ShouldDestroy
+        {
+            get
+            {
+                if (shouldDestroy == -1)
+                {
+                    shouldDestroy = !def.IsWeapon && (AmmoDef?.tradeTags?.Contains(AmmoInjector.destroyWithAmmoDisabledTag) ?? false)
+                        ? 1
+                        : 0;
+                }
+                return shouldDestroy == 1 && !Controller.settings.EnableAmmoSystem;
+            }
+        }
+
         public override void Tick()
         {
             // Self-destruct if ammo is disabled
-            if (!Controller.settings.EnableAmmoSystem && !def.IsWeapon && def is AmmoDef) Destroy(DestroyMode.Vanish);
+            if (ShouldDestroy) Destroy(DestroyMode.Vanish);
 
             base.Tick();
 


### PR DESCRIPTION
Changes:
- AmmoInjector doesn't toggle menuHidden and destroyOnDrop when tradeTags contains CE_Ammo
- AmmoThing doesn't destroy every tick with ammo system disabled if tradeTags doesn't contain CE_Ammo

This fixes the issue where almost every AmmoDef is deleted when the ammo system is disabled