### PR TITLE
Add T-45b Power Armor patch

### DIFF
--- a/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
+++ b/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>T-45b Power Armor</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== T-45b helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>1</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/statBases</xpath>
+					<value>
+						<ArmorRating_Electric>0.06</ArmorRating_Electric>
+					</value>
+				</li>
+
+				<!-- ========== T-45b armor ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases</xpath>
+					<value>
+						<Bulk>100</Bulk>
+						<WornBulk>15</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>15</CarryBulk>
+						<CarryWeight>90</CarryWeight>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.8</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases</xpath>
+					<value>
+						<ArmorRating_Electric>0.05</ArmorRating_Electric>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
+++ b/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
@@ -16,7 +16,7 @@
 						<WornBulk>1.5</WornBulk>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
@@ -45,6 +45,15 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/equippedStatOffsets</xpath>
+					<value>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+				
+				<!-- Deliberately omitted WearingGasMask ApparelHediffExtension, as we assume the T-45b Helmet is more comfortable than real-life gas masks -->
+				
 				<!-- ========== T-45b armor ========== -->
 
 				<li Class="PatchOperationAdd">


### PR DESCRIPTION
Patch brought over as part of the FastTrack merger

As the armor and helmet comes from a sci-fi video game, armor ratings are based on conjecture.