### PR TITLE
Add Rimmu-Nation Clothing patches

### DIFF
--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== 6B23-1 body armor ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_6B23Vest"]/statBases</xpath>
+					<value>
+						<Bulk>9</Bulk>
+						<WornBulk>6</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_6B23Vest"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_6B23Vest"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_6B23Vest"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_6B23Vest"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<!-- ========== 5.11 Tactec body armor ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_511TacTecVest"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_511TacTecVest"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_511TacTecVest"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_511TacTecVest"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>25</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_511TacTecVest"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<!-- ========== Crye CAGE body armor ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>25</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<!-- ========== AR500 armor (PMC) ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<!-- ========== AR500 armor ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<!-- ========== AR500 armor (Warrior) ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<!-- ========== Hunter Reactive ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveArmor"]/statBases</xpath>
+					<value>
+						<Bulk>100</Bulk>
+						<WornBulk>15</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveArmor"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>15</CarryBulk>
+						<CarryWeight>90</CarryWeight>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveArmor"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.8</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveArmor"]/statBases</xpath>
+					<value>
+						<ArmorRating_Electric>0.05</ArmorRating_Electric>
+					</value>
+				</li>
+
+				<!-- ========== Interceptor body armor (M81) ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_IBAM81Vest"]/statBases</xpath>
+					<value>
+						<Bulk>9</Bulk>
+						<WornBulk>6</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_IBAM81Vest"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_IBAM81Vest"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_IBAM81Vest"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_IBAM81Vest"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.36</ArmorRating_Heat>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear.xml
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Chicken hat ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_ChickenHatMGSV"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<!-- ========== FAST helmet black ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetBlack"]/statBases</xpath>
+					<value>
+						<Bulk>3.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetBlack"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== FAST helmet Multicam ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetMulticam"]/statBases</xpath>
+					<value>
+						<Bulk>3.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetMulticam"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== FAST helmet PMC ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetPMC"]/statBases</xpath>
+					<value>
+						<Bulk>4.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetPMC"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== Hunter Reactive helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveHelmet"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveHelmet"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>1</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_HunterReactiveHelmet"]/statBases</xpath>
+					<value>
+						<ArmorRating_Electric>0.06</ArmorRating_Electric>
+					</value>
+				</li>
+
+				<!-- ========== K6-3 helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_K63Helmet"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_K63Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== K6-3 helmet open ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_K63HelmetOpen"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_K63HelmetOpen"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Lynx-T helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmet"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Lynx-T helmet open ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmetOpen"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmetOpen"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== M1 helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_M1Helmet"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>0.375</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.143</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.386</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_M1Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== MASKA-1 helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_MASKA1Helmet"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>10</ArmorRating_Sharp>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_MASKA1Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== PASGT helmet DCU ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/statBases</xpath>
+					<value>
+						<Bulk>4</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+						<ArmorRating_Blunt>13</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== PASGT helmet M81 ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/statBases</xpath>
+					<value>
+						<Bulk>4</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+						<ArmorRating_Blunt>13</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== PT A-Bravo helmet black ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_PTABravoHelmetBlack"]/statBases</xpath>
+					<value>
+						<Bulk>3.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_PTABravoHelmetBlack"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== PT A-Bravo helmet Operator ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_PTABravoHelmetOperator"]/statBases</xpath>
+					<value>
+						<Bulk>4.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_PTABravoHelmetOperator"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== MICH helmet DPM ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_DPM"]/statBases</xpath>
+					<value>
+						<Bulk>4</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_DPM"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== MICH helmet Tan ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_Tan"]/statBases</xpath>
+					<value>
+						<Bulk>4</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_Tan"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+				<!-- ========== Crye Airframe helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeAirframeHelmet_Tan"]/statBases</xpath>
+					<value>
+						<Bulk>4.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Blunt>16</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.54</ArmorRating_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_CryeAirframeHelmet_Tan"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+					</value>
+				</li>  
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear_Crafting_Rimfeller.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear_Crafting_Rimfeller.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<li Class="PatchOperationFindMod">
+					<mods>
+						<li>Rimefeller</li>
+					</mods>
+					
+					<!-- If Rimefeller is also installed, have the PASGT helmets require Synthamide  for crafting -->					
+					<match Class="PatchOperationSequence">
+						<operations>
+						
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/costList</xpath>
+								<value>
+									<costList>
+										<Synthamide>10</Synthamide>
+									</costList>
+								</value>
+							</li>
+							
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/costList</xpath>
+								<value>
+									<costList>
+										<Synthamide>10</Synthamide>
+									</costList>
+								</value>
+							</li>
+						</operations>
+					</match>
+					
+					<!-- Otherwise, default to Devilstrand -->		
+					<nomatch Class="PatchOperationSequence">
+						<operations>
+						
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/costList</xpath>
+								<value>
+									<costList>
+										<DevilstrandCloth>10</DevilstrandCloth>
+									</costList>
+								</value>
+							</li>
+							
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/costList</xpath>
+								<value>
+									<costList>
+										<DevilstrandCloth>10</DevilstrandCloth>
+									</costList>
+								</value>
+							</li>
+						</operations>
+						
+					</nomatch>
+					
+				</li>
+				
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Backpacks.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Backpacks.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Backpack civilian ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Civilian"]/statBases</xpath>
+					<value>
+						<Bulk>2.5</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Civilian"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>25</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Civilian"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Backpack</li>
+							</layers>
+							<tags>
+								<li>IndustrialAdvanced</li>
+							</tags>
+							<wornGraphicPath>Things/Apparel/Belt/CivilianBackpack</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+				<!-- ========== Backpack military ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Military"]/statBases</xpath>
+					<value>
+						<Bulk>3.5</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Military"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>35</CarryBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Military"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Backpack</li>
+							</layers>
+							<tags>
+								<li>RN_Backpack</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/MilitaryBackpack</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+				<!-- ========== Backpack tactical ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Tactical"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Tactical"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>30</CarryBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Tactical"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Backpack</li>
+							</layers>
+							<tags>
+								<li>IndustrialAdvanced</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/AssaultBackpack</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+				<!-- ========== Backpack tactical sling ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Tactical_Sling"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Tactical_Sling"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>15</CarryBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_Tactical_Sling"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Backpack</li>
+							</layers>
+							<tags>
+								<li>IndustrialAdvanced</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/Tactical_SlingBackpack</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+				<!-- ========== Backpack pegasus elite ops ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_PegasusEliteOps"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_PegasusEliteOps"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>30</CarryBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Backpack_PegasusEliteOps"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<careIfWornByCorpse>false</careIfWornByCorpse>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Backpack</li>
+							</layers>
+							<tags>
+								<li>IndustrialAdvanced</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/EliteOpsBackpack</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Belts.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Belts.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== MOLLE ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Harness_MOLLE"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Harness_MOLLE"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>20</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Harness_MOLLE"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Webbing</li>
+							</layers>
+							<tags>
+								<li>IndustrialMilitaryBasic</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/TacticalHarness</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+				<!-- ========== ALICE ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Harness_ALICE"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+						<WornBulk>3</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Harness_ALICE"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Harness_ALICE"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Webbing</li>
+							</layers>
+							<tags>
+								<li>IndustrialMilitaryBasic</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/ALICE_Harness</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+				<!-- ========== Handgun holsters ========== -->
+				
+				<!-- Shared with other CP / RH / RN mods - make sure not to apply redundant patches and cause duplicate XML node errors -->
+
+				<li Class="PatchOperationSequence">
+					<success>Always</success>
+					<operations>
+						<li Class="PatchOperationTest">
+							<xpath>Defs/ThingDef[defName="RNApparel_Holsters_Shoulder"]/statBases/Bulk</xpath>
+							<success>Invert</success>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="RNApparel_Holsters_Shoulder"]/statBases</xpath>
+							<value>
+								<Bulk>2.5</Bulk>
+								<WornBulk>1</WornBulk>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="RNApparel_Holsters_Shoulder"]/equippedStatOffsets</xpath>
+							<value>
+								<CarryBulk>2.5</CarryBulk>
+							</value>
+						</li>
+					</operations>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Holsters_Shoulder"]/apparel
+					</xpath>
+					<value>
+						<apparel>
+							<bodyPartGroups>
+								<li>Shoulders</li>
+							</bodyPartGroups>
+							<layers>
+								<li>Webbing</li>
+							</layers>
+							<tags>
+								<li>IndustrialMilitaryBasic</li>
+							</tags>
+							<defaultOutfitTags>
+								<li>Soldier</li>
+							</defaultOutfitTags>
+							<wornGraphicPath>Things/Apparel/Belt/ShoulderHolster</wornGraphicPath>
+						</apparel>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Headgear.xml
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing (1.0)</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Berets ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Beret" or
+					defName="RNApparel_BeretSOG"					
+					]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Beret" or
+					defName="RNApparel_BeretSOG"					
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Baseball Caps ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_PatchCap" or
+					defName="RNApparel_BackwardsCap" or
+					defName="RNApparel_AceCap" or
+					defName="RNApparel_LegendCap" or
+					defName="RNApparel_PunisherCap" or
+					defName="RNApparel_MAGACap" or
+					defName="RNApparel_M81Cap" or
+					defName="RNApparel_MulticamCap" or
+					defName="RNApparel_BrownCap" or
+					defName="RNApparel_NomadCap"
+					]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_PatchCap" or
+					defName="RNApparel_BackwardsCap" or
+					defName="RNApparel_AceCap" or
+					defName="RNApparel_LegendCap" or
+					defName="RNApparel_PunisherCap" or
+					defName="RNApparel_MAGACap" or
+					defName="RNApparel_M81Cap" or
+					defName="RNApparel_MulticamCap" or
+					defName="RNApparel_BrownCap" or
+					defName="RNApparel_NomadCap"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Boonie Hats ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_PlainBoonie" or
+					defName="RNApparel_M81Boonie" or
+					defName="RNApparel_MulticamBoonie"
+					]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_PlainBoonie" or
+					defName="RNApparel_M81Boonie" or
+					defName="RNApparel_MulticamBoonie"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Bandanas ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_BandanaRed" or 
+					defName="RNApparel_BandanaTan"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Balaclavas ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Balaclava" or
+					defName="RNApparel_BalaclavaSkully" or
+					defName="RNApparel_BalaclavaRiley" or
+					defName="RNApparel_BalaclavaKeegan"
+					]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Balaclava" or
+					defName="RNApparel_BalaclavaSkully" or
+					defName="RNApparel_BalaclavaRiley" or
+					defName="RNApparel_BalaclavaKeegan"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Ghillie Suit Hood ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_NewGhillieHood"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+						<WornBulk>2</WornBulk>
+					</value>
+				</li>
+
+				<!-- ========== Tuques / Beanies ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Beanie" or
+					defName="RNApparel_M81Tuque" or
+					defName="RNApparel_MulticamTuque"
+					]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Beanie" or
+					defName="RNApparel_M81Tuque" or
+					defName="RNApparel_MulticamTuque"
+					]/apparel/layers/li[.="Overhead"]</xpath>
+					<value>
+						<li>MiddleHead</li>
+					</value>
+				</li>
+
+				<!-- ========== Beanie Division ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]/statBases</xpath>
+					<value>
+						<Bulk>1.5</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]/equippedStatOffsets</xpath>
+					<value>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]/apparel/layers/li[.="Overhead"]</xpath>
+					<value>
+						<li>MiddleHead</li>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]</xpath>
+					<value>
+						<li Class="CombatExtended.ApparelHediffExtension">
+							<hediff>WearingGasMask</hediff>
+						</li>
+					</value>
+				</li>
+
+				<!-- ========== 4A1 gasmask ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_4A1Gasmask"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_4A1Gasmask"]/equippedStatOffsets</xpath>
+					<value>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_4A1Gasmask"]/apparel/layers</xpath>
+					<value>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="RNApparel_4A1Gasmask"]</xpath>
+					<value>
+						<li Class="CombatExtended.ApparelHediffExtension">
+							<hediff>WearingGasMask</hediff>
+						</li>
+					</value>
+				</li>
+
+				<!-- ========== GP-5 gasmask ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GP5Gasmask"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GP5Gasmask"]/equippedStatOffsets</xpath>
+					<value>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GP5Gasmask"]/apparel/layers</xpath>
+					<value>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="RNApparel_GP5Gasmask"]</xpath>
+					<value>
+						<li Class="CombatExtended.ApparelHediffExtension">
+							<hediff>WearingGasMask</hediff>
+						</li>
+					</value>
+				</li>
+
+				<!-- ========== Halfmask (GTA) ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GTAHalfMask"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>0.5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GTAHalfMask"]/equippedStatOffsets</xpath>
+					<value>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GTAHalfMask"]/apparel/layers</xpath>
+					<value>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="RNApparel_GTAHalfMask"]</xpath>
+					<value>
+						<li Class="CombatExtended.ApparelHediffExtension">
+							<hediff>WearingGasMask</hediff>
+						</li>
+					</value>
+				</li>
+
+				<!-- ========== Field Caps ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_MilitaryCap_DCU" or
+					defName="RNApparel_MilitaryCap_M81cam" or
+					defName="RNApparel_MilitaryCap_Multicam"
+					]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_MilitaryCap_DCU" or
+					defName="RNApparel_MilitaryCap_M81cam" or
+					defName="RNApparel_MilitaryCap_Multicam"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_OnSkin.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Combat Fleece / Hoodie ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_combats_Fleece" or
+					defName="RNApparel_combats_FleeceBlack"
+					]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_combats_Fleece" or
+					defName="RNApparel_combats_FleeceBlack"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== GORKA 4 ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_combats_GORKA4C"]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<WornBulk>4</WornBulk>
+						<ArmorRating_Sharp>0.075</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_combats_GORKA4C"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Combat Uniforms ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_combats_DCU" or
+					defName="RNApparel_combats_DPM" or
+					defName="RNApparel_combats_M81C" or
+					defName="RNApparel_combats_Multicam"
+					]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_combats_DCU" or
+					defName="RNApparel_combats_DPM" or
+					defName="RNApparel_combats_M81C" or
+					defName="RNApparel_combats_Multicam"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Combat Uniform C&C Red Alert Tanya ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Combats_Tanya"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Combats_Tanya"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Plaid Collar Shirts with Jeans ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Plaid_Black" or
+					defName="RNApparel_Plaid_Blue" or
+					defName="RNApparel_Plaid_Green" or
+					defName="RNApparel_Plaid_Red" or
+					defName="RNApparel_Plaid_Tan"
+					]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Plaid_Black" or
+					defName="RNApparel_Plaid_Blue" or
+					defName="RNApparel_Plaid_Green" or
+					defName="RNApparel_Plaid_Red" or
+					defName="RNApparel_Plaid_Tan"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Tank Tops with Trousers ========== -->
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel__Tank_ExplorerA" or
+					defName="RNApparel_Tank_ExplorerB" or
+					defName="RNApparel_GymOutfit_Blank" or
+					defName="RNApparel_Tank_Tenlyashka"
+					]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel__Tank_ExplorerA" or
+					defName="RNApparel_Tank_ExplorerB" or
+					defName="RNApparel_GymOutfit_Blank" or
+					defName="RNApparel_Tank_Tenlyashka"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Button Shirts with Trousers ========== -->
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Shirt_PUBGGray" or
+					defName="RNApparel_Shirt_PUBGNavy" or
+					defName="RNApparel_Shirt_Office" or
+					defName="RNApparel_Shirt_OffDuty" or
+					defName="RNApparel_Shirt_Spy" or
+					defName="RNApparel_Shirt_Wick"
+					]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Shirt_PUBGGray" or
+					defName="RNApparel_Shirt_PUBGNavy" or
+					defName="RNApparel_Shirt_Office" or
+					defName="RNApparel_Shirt_OffDuty" or
+					defName="RNApparel_Shirt_Spy" or
+					defName="RNApparel_Shirt_Wick"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Light Shirts with Trousers ========== -->
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Shirt_LiteDDPM" or
+					defName="RNApparel_Shirt_EllieShirt" or
+					defName="RNApparel_Shirt_NomadShirt" or
+					defName="RNApparel_Polo_WPSRed" or
+					defName="RNApparel_Shirt_ButSarge"
+					]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Shirt_LiteDDPM" or
+					defName="RNApparel_Shirt_EllieShirt" or
+					defName="RNApparel_Shirt_NomadShirt" or
+					defName="RNApparel_Polo_WPSRed" or
+					defName="RNApparel_Shirt_ButSarge"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				
+				<!-- ========== Causals Division ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Hoodie_Ryan"]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Hoodie_Ryan"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Ada Wong outfit (Resident Evil) ========== -->
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_Shirt_AdaREmake"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>3</WornBulk>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_Shirt_AdaREmake"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Shell.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Shell.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Rimmu-Nation - Clothing (1.0)</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Smocks / Parkas ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Parka" or
+					defName="RNApparel_Parka_M65Blank"
+					]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Parka" or
+					defName="RNApparel_Parka_M65Blank"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Ghillie suit ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RNApparel_GhillieSuit"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<WornBulk>7.5</WornBulk>
+					</value>
+				</li>
+
+				<!-- ========== Trench Coats ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_TrenchCoat_Brown" or
+					defName="RNApparel_TrenchCoat_Gray" or
+					defName="RNApparel_TrenchCoat_PUBG"
+					]/statBases</xpath>
+					<value>
+						<Bulk>12</Bulk>
+						<WornBulk>7</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_TrenchCoat_Brown" or
+					defName="RNApparel_TrenchCoat_Gray" or
+					defName="RNApparel_TrenchCoat_PUBG"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Suit Jackets ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Blazer_Black" or
+					defName="RNApparel_Blazer_Blue"
+					]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Blazer_Black" or
+					defName="RNApparel_Blazer_Blue"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Tracksuit Jackets ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Tracksuit_Blue" or
+					defName="RNApparel_Tracksuit_Red"
+					]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Tracksuit_Blue" or
+					defName="RNApparel_Tracksuit_Red"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Leather Jackets ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Jacket_Bomber" or
+					defName="RNApparel_Jacket_Division" or
+					defName="RNApparel_Jacket_LeatherBlank"
+					]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>2</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_Jacket_Bomber" or
+					defName="RNApparel_Jacket_Division" or
+					defName="RNApparel_Jacket_LeatherBlank"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Combat Jackets ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_CombatJacket_Urban" or
+					defName="RNApparel_CombatJacket_Olive" or
+					defName="RNApparel_CombatJacket_DCU" or
+					defName="RNApparel_CombatJacket_DPM" or
+					defName="RNApparel_CombatJacket_M81C" or
+					defName="RNApparel_CombatJacket_Multicam"
+					]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_CombatJacket_Urban" or
+					defName="RNApparel_CombatJacket_Olive" or
+					defName="RNApparel_CombatJacket_DCU" or
+					defName="RNApparel_CombatJacket_DPM" or
+					defName="RNApparel_CombatJacket_M81C" or
+					defName="RNApparel_CombatJacket_Multicam"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- ========== Tactical Jackets ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_TacticalJacket" or
+					defName="RNApparel_TacticalJacket_M81C" or
+					defName="RNApparel_TacticalJacket_Multicam"
+					]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+					defName="RNApparel_TacticalJacket" or
+					defName="RNApparel_TacticalJacket_M81C" or
+					defName="RNApparel_TacticalJacket_Multicam"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Patches brought over as part of the FastTrack merger, and updated to RimWorld 1.1 standards

Notes:
* All apparel balanced to 1.6/1.8 standards