### PR TITLE
Add CP Metal Gear Solid and Red Horse Faction - MSF patches

### DIFF
--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -90,5 +90,16 @@
     <defName>ArrowVenom</defName>
     <hediff>VenomousArrow</hediff>
   </DamageDef>
+  
+  <DamageDef ParentName="Bullet">
+    <defName>Tranquilizer</defName>
+    <label>tranquilizer</label>
+    <additionalHediffs>
+      <li>
+        <hediff>Tranquilizer</hediff>
+        <severityPerDamageDealt>0.9</severityPerDamageDealt>
+      </li>
+    </additionalHediffs>
+  </DamageDef>
 
 </Defs>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Ammo_NonLethal.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Ammo_NonLethal.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Metal Gear Solid</li>
+			<li>[RH] Faction: Militaires Sans Frontieres</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Non-lethal tranquilizer 9x19mm Parabellum pistol cartridge and ammoset for non-lethal pistols -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- ==================== AmmoSet ========================== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_9x19mmPara_NonLethal</defName>
+							<label>9x19mm Para (Tranq)</label>
+							<ammoTypes>
+								<Ammo_9x19mmPara_NL>Bullet_9x19mmPara_NL</Ammo_9x19mmPara_NL>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<!-- ==================== Ammo ========================== -->	
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x19mmParaBase">
+							<defName>Ammo_9x19mmPara_NL</defName>
+							<label>9x19mm Para cartridge (Tranq)</label>
+							<graphicData>
+								<texPath>ThirdParty/CP Metal Gear Solid/Pistol/NL</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>0.31</MarketValue>
+							</statBases>
+							<ammoClass>TranqNonLethal</ammoClass>
+							<cookOffProjectile>Bullet_9x19mmPara_NL</cookOffProjectile>
+						</ThingDef>
+
+						<!-- ================== Projectiles ================== -->
+
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base9x19mmParaBullet) -->
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base9x19mmParaBullet">
+							<defName>Bullet_9x19mmPara_NL</defName>
+							<label>9mm Para bullet (Tranq)</label>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Tranquilizer</damageDef>
+								<damageAmountBase>1</damageAmountBase>
+								<armorPenetrationSharp>2</armorPenetrationSharp>
+								<armorPenetrationBlunt>10.820</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<!-- ==================== Recipes ========================== -->
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_9x19mmPara_NL</defName>
+							<label>make 9x19mm Parabellum (Tranq) cartridge x500</label>
+							<description>Craft 500 9x19mm Parabellum (Tranq) cartridges.</description>
+							<jobString>Making 9x19mm Parabellum (Tranq) cartridges.</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>14</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>MedicineHerbal</li>
+										</thingDefs>
+									</filter>
+									<count>12</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+									<li>MedicineHerbal</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_9x19mmPara_NL>500</Ammo_9x19mmPara_NL>
+							</products>
+							<workAmount>5000</workAmount>
+						</RecipeDef>
+
+					</value>
+				</li>
+
+				<!-- Non-lethal tranquilizer 7.62x51mm NATO rifle cartridge and ammoset for non-lethal rifles -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- ==================== AmmoSet ========================== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_762x51mmNATO_NonLethal</defName>
+							<label>7.62x51mm NATO (Tranq)</label>
+							<ammoTypes>
+								<Ammo_762x51mmNATO_NL>Bullet_762x51mmNATO_NL</Ammo_762x51mmNATO_NL>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<!-- ==================== Ammo ========================== -->	
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+							<defName>Ammo_762x51mmNATO_NL</defName>
+							<label>7.62x51mm NATO cartridge (Tranq)</label>
+							<graphicData>
+								<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>0.5</MarketValue>
+							</statBases>
+							<ammoClass>TranqNonLethal</ammoClass>
+							<cookOffProjectile>Bullet_762x51mmNATO_NL</cookOffProjectile>
+						</ThingDef>
+
+						<!-- ================== Projectiles ================== -->
+
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base762x51mmNATOBullet) -->
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+							<defName>Bullet_762x51mmNATO_NL</defName>
+							<label>7.62mm NATO bullet (Tranq)</label>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Tranquilizer</damageDef>
+								<damageAmountBase>1</damageAmountBase>
+								<armorPenetrationSharp>21</armorPenetrationSharp>
+								<armorPenetrationBlunt>86.28</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<!-- ==================== Recipes ========================== -->
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_762x51mmNATO_NL</defName>
+							<label>make 7.62x51mm NATO (Tranq) cartridge x500</label>
+							<description>Craft 500 7.62x51mm NATO (Tranq) cartridges.</description>
+							<jobString>Making 7.62x51mm NATO (Tranq) cartridges.</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>22</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>MedicineHerbal</li>
+										</thingDefs>
+									</filter>
+									<count>20</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+									<li>MedicineHerbal</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_762x51mmNATO_NL>500</Ammo_762x51mmNATO_NL>
+							</products>
+							<workAmount>8200</workAmount>
+						</RecipeDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_Armor.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_Armor.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== Exo Suit THI ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuit_GrayFox"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuit_GrayFox"]/statBases</xpath>
+				<value>
+					<Bulk>15</Bulk>
+					<WornBulk>10</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuit_GrayFox"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryWeight>30</CarryWeight>
+					<!-- Essentially cancel out the added bulk of the exosuit -->
+					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuit_GrayFox"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuit_GrayFox"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuit_GrayFox"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>0.8</ArmorRating_Heat>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_Armor_Headgear.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== PASGT helmet FOXHOUND ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_PASGTFOXHOUNDHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					<ArmorRating_Blunt>13</ArmorRating_Blunt>
+					<ArmorRating_Heat>0.54</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_PASGTFOXHOUNDHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- ========== Exo Suit Helmet THI ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuitHelmet_GrayFox"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuitHelmet_GrayFox"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuitHelmet_GrayFox"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_ExoSuitHelmet_GrayFox"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>1</ArmorRating_Heat>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_Headgear.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== bandana FOX & bandana FOXHOUND ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_Bandana_FOX" or 
+					defName="RNApparel_Bandana_FOX_II"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- ========== beret (FOXHOUND) ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_Beret_FOXHOUND"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_Beret_FOXHOUND"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<!-- Equivalent to vanilla fabric hats -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Apparel_OnSkin.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== sneaking suit FOX & sneaking suit FOXHOUND ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_SneakingSuit_FOX" or 
+					defName="RNApparel_SneakingSuit_FOXHOUND"
+				]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_SneakingSuit_FOX" or 
+					defName="RNApparel_SneakingSuit_FOXHOUND"
+				]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>15</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_SneakingSuit_FOX" or 
+					defName="RNApparel_SneakingSuit_FOXHOUND"
+				]/statBases</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>3</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_SneakingSuit_FOX" or 
+					defName="RNApparel_SneakingSuit_FOXHOUND"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_SneakingSuit_FOX" or 
+					defName="RNApparel_SneakingSuit_FOXHOUND"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>13</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_SneakingSuit_FOX" or 
+					defName="RNApparel_SneakingSuit_FOXHOUND"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_MeleeWeapon.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_MeleeWeapon.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== Longsword / Katana ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHMelee_MGS_HFBlade"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.57</cooldownTime>
+							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>RHMelee_HFBladeStab</li>
+							</capacities>
+							<power>55</power>
+							<cooldownTime>1.57</cooldownTime>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
+							<armorPenetrationSharp>400</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>RHMelee_HFBladeSlash</li>
+							</capacities>
+							<power>50</power>
+							<cooldownTime>1.21</cooldownTime>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
+							<armorPenetrationSharp>216</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHMelee_MGS_HFBlade"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<MeleeCounterParryBonus>0.78</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHMelee_MGS_HFBlade"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.56</MeleeCritChance>
+						<MeleeParryChance>0.58</MeleeParryChance>
+						<MeleeDodgeChance>0.23</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_MeleeWeapon.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_MeleeWeapon.xml
@@ -17,11 +17,12 @@
 						<li Class="CombatExtended.ToolCE">
 							<label>handle</label>
 							<capacities>
-								<li>Poke</li>
+								<li>Blunt</li>
 							</capacities>
 							<power>2</power>
-							<cooldownTime>1.57</cooldownTime>
-							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+							<chanceFactor>0.33</chanceFactor>
+							<cooldownTime>1.52</cooldownTime>
+							<armorPenetrationBlunt>0.500</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -29,10 +30,10 @@
 							<capacities>
 								<li>RHMelee_HFBladeStab</li>
 							</capacities>
-							<power>55</power>
-							<cooldownTime>1.57</cooldownTime>
-							<armorPenetrationBlunt>50</armorPenetrationBlunt>
-							<armorPenetrationSharp>400</armorPenetrationSharp>
+							<power>16</power>
+							<cooldownTime>1</cooldownTime>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+							<armorPenetrationSharp>85</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -40,10 +41,10 @@
 							<capacities>
 								<li>RHMelee_HFBladeSlash</li>
 							</capacities>
-							<power>50</power>
-							<cooldownTime>1.21</cooldownTime>
-							<armorPenetrationBlunt>50</armorPenetrationBlunt>
-							<armorPenetrationSharp>216</armorPenetrationSharp>
+							<power>42</power>
+							<cooldownTime>0.5</cooldownTime>
+							<armorPenetrationBlunt>40</armorPenetrationBlunt>
+							<armorPenetrationSharp>75</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -62,9 +63,9 @@
 				<xpath>Defs/ThingDef[defName="RHMelee_MGS_HFBlade"]</xpath>
 				<value>
 					<equippedStatOffsets>
-						<MeleeCritChance>0.56</MeleeCritChance>
-						<MeleeParryChance>0.58</MeleeParryChance>
-						<MeleeDodgeChance>0.23</MeleeDodgeChance>
+						<MeleeCritChance>4</MeleeCritChance>
+						<MeleeParryChance>1.2</MeleeParryChance>
+						<MeleeDodgeChance>0.4</MeleeDodgeChance>
 					</equippedStatOffsets>
 				</value>
 			</li>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_PawnKindDefs.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_PawnKindDefs.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== Reduce meals and medicine carried by all pawns ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[@Name="RH_FOX_Bare"]/invNutrition</xpath>
+				<value>
+					<invNutrition>1</invNutrition>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[
+					defName="RH_FOX_Infiltrator" or
+					defName="RH_FOX_QRF" or
+					defName="RH_FOX_CyborgNinja"
+				]/inventoryOptions/subOptionsChooseOne/li/countRange</xpath>
+				<value>
+					<countRange>
+						<min>0</min>
+						<max>1</max>
+					</countRange>
+				</value>
+			</li>
+
+			<!-- ========== FOX / FOXHOUND QRF Operator pawns should spawn with ammo appropriate to their primary weapon, as well as a sidearm (and its own ammo) ========== -->
+			
+			<!-- First remove redundant MK23 from pawn's existing primary weaponTags -->
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/PawnKindDef[defName="RH_FOX_QRF"]/weaponTags/li[.="RN_MK23_Loud"]</xpath>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RH_FOX_QRF"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>6</min>
+							<max>8</max>
+						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<generateChance>1</generateChance>
+								<magazineCount>
+									<min>2</min>
+									<max>3</max>
+								</magazineCount>	
+								<weaponTags>
+									<li>RN_MK23_Loud</li>
+								</weaponTags>
+							</li>
+						</sidearms>
+					</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_RangedIndustrial_Pistols.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_RangedIndustrial_Pistols.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+
+			<!-- ========== M9A1-S Tranq ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M9NLPistol</defName>
+				<statBases>
+					<Mass>1.13</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>1.64</SwayFactor>
+					<Bulk>3.80</Bulk>
+					<WorkToMake>7500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>30</Steel>
+					<ComponentIndustrial>3</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_NL</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>RNShotWUSPistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>2</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>15</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara_NonLethal</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- ========== SOCOM Mk 23 MOD 0 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_MK23P_Loud</defName>
+				<statBases>
+					<Mass>1.35</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.176</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>2.45</Bulk>
+					<WorkToMake>7500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>30</Steel>
+					<ComponentIndustrial>3</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>RNShot_1911Hellfighter</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>12</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_45ACP</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+			
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_M9NLPistol" or
+					defName="RNGun_MK23P_Loud"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_RangedIndustrial_R_Bullpup_Style.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_RangedIndustrial_R_Bullpup_Style.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+Chicken Plucker's Project Red Horse mods often have duplicate items, apparels and defs shared between them,
+so this patch will only be applied if:
+
+Metal Gear Solid is active && Rimmu-Nation Weapons is NOT active
+
+If both mods are active, the CE patch from Rimmu-Nation Weapons should automatically take over
+-->
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] Metal Gear Solid</li>
+		</mods>
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>[CP] Rimmu-Nation - Weapons</li>
+			</mods>
+			<nomatch Class="PatchOperationSequence">
+				<operations>
+
+					<!-- ========== FAMAS ========== -->
+
+					<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+						<defName>RNGun_FAMASAR</defName>
+						<statBases>
+							<Mass>3.61</Mass>
+							<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+							<SightsEfficiency>1.00</SightsEfficiency>
+							<ShotSpread>0.07</ShotSpread>
+							<SwayFactor>1.12</SwayFactor>
+							<Bulk>7.57</Bulk>
+							<WorkToMake>37500</WorkToMake>
+						</statBases>
+						<costList>
+							<Chemfuel>10</Chemfuel>
+							<Steel>45</Steel>
+							<ComponentIndustrial>6</ComponentIndustrial>
+						</costList>
+						<Properties>
+							<recoilAmount>1.44</recoilAmount>
+							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+							<warmupTime>1.1</warmupTime>
+							<range>40</range>
+							<burstShotCount>6</burstShotCount>
+							<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+							<soundCast>RNShot_GenericBullpup_II</soundCast>
+							<soundCastTail>GunTail_Medium</soundCastTail>
+							<muzzleFlashScale>9</muzzleFlashScale>
+						</Properties>
+
+						<AmmoUser>
+							<magazineSize>25</magazineSize>
+							<reloadTime>4.5</reloadTime>
+							<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+						</AmmoUser>
+
+						<FireModes>
+							<aiUseBurstMode>FALSE</aiUseBurstMode>
+							<aiAimMode>AimedShot</aiAimMode>
+							<aimedBurstShotCount>3</aimedBurstShotCount>
+						</FireModes>
+
+						<!-- No additional CE weaponTags needed -->
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="RNGun_FAMASAR"]/tools</xpath>
+						<value>
+							<tools>
+								<li Class="CombatExtended.ToolCE">
+									<label>stock</label>
+									<capacities>
+										<li>Blunt</li>
+									</capacities>
+									<power>8</power>
+									<cooldownTime>1.55</cooldownTime>
+									<chanceFactor>1.5</chanceFactor>
+									<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+									<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+								</li>
+								<li Class="CombatExtended.ToolCE">
+									<label>barrel</label>
+									<capacities>
+										<li>Blunt</li>
+									</capacities>
+									<power>5</power>
+									<cooldownTime>2.02</cooldownTime>
+									<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+									<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+								</li>
+								<li Class="CombatExtended.ToolCE">
+									<label>muzzle</label>
+									<capacities>
+										<li>Poke</li>
+									</capacities>
+									<power>8</power>
+									<cooldownTime>1.55</cooldownTime>
+									<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+									<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+								</li>
+							</tools>
+						</value>
+					</li>
+
+				</operations>
+			</nomatch>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Scenario.xml
+++ b/Patches/CP Metal Gear Solid/CP_MGS_CE_Patch_Scenario.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] Metal Gear Solid</modName>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ScenarioDef[defName="RH_Scenario_FOX"]/scenario/parts</xpath>
+				<value>
+				
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_9x19mmPara_NL</thingDef>
+						<count>500</count>
+					</li>
+					
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_45ACP_FMJ</thingDef>
+						<count>500</count>
+					</li>
+					
+				</value>
+			</li>
+			
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_Armor.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_Armor.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========= Fragmentation Protective Vest (MSF) ========= -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_FPV_MSF"]/statBases</xpath>
+				<value>
+					<Bulk>7.5</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_FPV_MSF"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_FPV_MSF"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_FPV_MSF"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_FPV_MSF"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>0.36</ArmorRating_Heat>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_Headgear.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Balaclava MSF ========== -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_Balaclava_MSF"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_Balaclava_MSF"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<!-- Equivalent to vanilla tuque -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<!-- ========== Bandana MSF ========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_Bandana_MSF"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<!-- ========== Aviator Sunglasses MSF ========== -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_MSF_Aviator"]/statBases</xpath>
+				<value>
+					<Bulk>0.5</Bulk>
+					<WornBulk>0.5</WornBulk>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_OnSkin.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Combat Uniform MSF, Combat Uniform Miller ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_combats_MSF" or
+					defName="RNApparel_combats_Miller"
+				]/statBases</xpath>
+				<value>
+					<Bulk>8</Bulk>
+					<WornBulk>3</WornBulk>
+					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+					<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_combats_MSF" or
+					defName="RNApparel_combats_Miller"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- ========== Sneaking Suit MSF ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_SneakingSuit_MSF"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_SneakingSuit_MSF"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>15</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_SneakingSuit_MSF"]/statBases</xpath>
+				<value>
+					<Bulk>8</Bulk>
+					<WornBulk>3</WornBulk>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_SneakingSuit_MSF"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_SneakingSuit_MSF"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>13</ArmorRating_Blunt>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_Shell.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_Shell.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Parka M65 MSF ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_Parka_M65MSF"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RNApparel_Parka_M65MSF"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>10</CarryBulk>
+					<!-- Integrated ALICE harness -->
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNApparel_Parka_M65MSF"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_NonLethal_Guns.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_NonLethal_Guns.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== M2000-NL Sniper Rifle ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M2000NLRifle</defName>
+				<statBases>
+					<Mass>7.39</Mass>
+					<RangedWeapon_Cooldown>1.16</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.48</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.98</SwayFactor>
+					<Bulk>8.73</Bulk>
+					<WorkToMake>27500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>5</Chemfuel>
+					<Steel>65</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_NL</defaultProjectile>
+					<warmupTime>1.5</warmupTime>
+					<range>75</range>
+					<soundCast>RNShot_BoltGenericSD</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Regular</recoilPattern>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO_NonLethal</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNGun_M2000NLRifle"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- ========== WU Silenced Pistol ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_WUSPistol</defName>
+				<statBases>
+					<Mass>1.01</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>1.06</SwayFactor>
+					<Bulk>2.17</Bulk>
+					<WorkToMake>7000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>25</Steel>
+					<ComponentIndustrial>3</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>2.48</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_NL</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>RNShotWUSPistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Regular</recoilPattern>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>8</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara_NonLethal</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNGun_WUSPistol"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_PawnKinds_MSF_Soldiers.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_PawnKinds_MSF_Soldiers.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+			
+			<!-- ========== MSF faction pawns should spawn backpacks, allowing them to carry their (huge) inventory ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PawnKindDef[
+					defName="RH_MSF_Patrol" or
+					defName="RH_MSF_Marksman" or
+					defName="RH_MSF_Sniper" or
+					defName="RH_MSF_Assault" or
+					defName="RH_MSF_Assault_TierII" or
+					defName="RH_MSF_Gunner" or
+					defName="RH_MSF_Grenadier" or
+					defName="RH_MSF_Boss" or
+					defName="RH_MSF_Elite" or
+					defName="RH_MSF_Trader" or
+					defName="RH_MSF_SpecialUnit"
+				]/apparelRequired</xpath>
+				<value>
+					<li>Apparel_Backpack</li>
+				</value>
+			</li>
+			
+			<!-- ========== MSF faction pawns should spawn with ammo appropriate to their primary weapon ========== -->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+					defName="RH_MSF_Patrol" or
+					defName="RH_MSF_Marksman" or
+					defName="RH_MSF_Sniper" or
+					defName="RH_MSF_Assault" or
+					defName="RH_MSF_Assault_TierII" or
+					defName="RH_MSF_Boss" or
+					defName="RH_MSF_Elite" or
+					defName="RH_MSF_Trader" or
+					defName="RH_MSF_SpecialUnit"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>6</min>
+							<max>8</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RH_MSF_Gunner"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>3</min>
+							<max>4</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="RH_MSF_Grenadier"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+						<primaryMagazineCount>
+							<min>8</min>
+							<max>10</max>
+						</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== China Lake Grenade Launcher (Mercenary) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNEx_ChinaLakeMercenaryGL</defName>
+				<statBases>
+					<Mass>3.72</Mass>
+					<RangedWeapon_Cooldown>1.01</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.16</ShotSpread>
+					<SwayFactor>1.25</SwayFactor>
+					<Bulk>8.75</Bulk>
+					<WorkToMake>9500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>10</WoodLog>
+					<Steel>45</Steel>
+					<ComponentIndustrial>1</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>44</range>
+					<ticksBetweenBurstShots>120</ticksBetweenBurstShots>
+					<soundCast>RNShot_ChinaLakeGL</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>3</magazineSize>
+					<reloadTime>2.55</reloadTime>
+					<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNEx_ChinaLakeMercenaryGL"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- ========== RPG-7 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNEx_RPG7RL</defName>
+				<statBases>
+					<Mass>7.00</Mass>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.16</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1.68</SwayFactor>
+					<Bulk>10.50</Bulk>
+					<WorkToMake>25500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>5</WoodLog>
+					<Steel>70</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_RPG7Grenade_HEAT</defaultProjectile>
+					<warmupTime>2.035</warmupTime>
+					<range>40</range>
+					<soundCast>RNShotRPG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<reloadTime>8.6</reloadTime>
+					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNEx_RPG7RL"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>2.44</cooldownTime>
+							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_LMG.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_LMG.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== M60 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M60LMG</defName>
+				<statBases>
+					<Mass>10.50</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>1.51</SwayFactor>
+					<Bulk>14.05</Bulk>
+					<WorkToMake>40500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>15</Chemfuel>
+					<Steel>85</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.30</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>75</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>RNShotM60LMG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_MachineGun</li>
+				</weaponTags>
+			</li>
+
+			<!-- ========== PKM ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_PKMLMG</defName>
+				<statBases>
+					<Mass>7.50</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.36</SwayFactor>
+					<Bulk>14.92</Bulk>
+					<WorkToMake>36000</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>10</WoodLog>
+					<Steel>80</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.45</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<warmupTime>1.3</warmupTime>
+					<range>75</range>
+					<soundCast>RNShotM240B</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_762x54mmR</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_MachineGun</li>
+				</weaponTags>
+			</li>
+
+			<!-- ========== RPK-74 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_RPK74LMG</defName>
+				<statBases>
+					<Mass>4.80</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.06</SwayFactor>
+					<Bulk>12.40</Bulk>
+					<WorkToMake>29500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>10</WoodLog>
+					<Steel>65</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.54</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>75</range>
+					<burstShotCount>10</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<soundCast>RNShotRPK</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>75</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_545x39mmSoviet</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_MachineGun</li>
+				</weaponTags>
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_M60LMG" or
+					defName="RNGun_PKMLMG" or
+					defName="RNGun_RPK74LMG"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_M_BoltAction.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_M_BoltAction.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Mosin Nagant ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_MosinNagant_Mercenary</defName>
+				<statBases>
+					<Mass>4.00</Mass>
+					<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.21</SightsEfficiency>
+					<ShotSpread>0.03</ShotSpread>
+					<SwayFactor>1.67</SwayFactor>
+					<Bulk>12.32</Bulk>
+					<WorkToMake>15500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>15</WoodLog>
+					<Steel>55</Steel>
+					<ComponentIndustrial>2</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+					<warmupTime>1.275</warmupTime>
+					<range>75</range>
+					<soundCast>RNShot_BoltActionOldie</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>4.3</reloadTime>
+					<ammoSet>AmmoSet_762x54mmR</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== Remington 700 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_R700Sn</defName>
+				<statBases>
+					<Mass>4.08</Mass>
+					<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.72</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.15</SwayFactor>
+					<Bulk>12.08</Bulk>
+					<WorkToMake>26000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>15</Chemfuel>
+					<Steel>55</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.9</warmupTime>
+					<range>75</range>
+					<soundCast>RNShotM40Sniper</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>4.25</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_MosinNagant_Mercenary" or
+					defName="RNGun_R700Sn"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>			

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_M_DMR.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_M_DMR.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Dragunov SVD ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_DragunovDMR</defName>
+				<statBases>
+					<Mass>4.30</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.24</SightsEfficiency>
+					<ShotSpread>0.04</ShotSpread>
+					<SwayFactor>1.70</SwayFactor>
+					<Bulk>12.25</Bulk>
+					<WorkToMake>23000</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>10</WoodLog>
+					<Steel>60</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>75</range>
+					<soundCast>RNShotDragunov</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x54mmR</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== M21 SWS ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M21DMR</defName>
+				<statBases>
+					<Mass>5.27</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.60</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>1.75</SwayFactor>
+					<Bulk>11.18</Bulk>
+					<WorkToMake>29000</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>15</WoodLog>
+					<Steel>55</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>76</range>
+					<soundCast>RNShot_M14DMR</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== Walther WA 2000 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_WA2000DMR</defName>
+				<statBases>
+					<Mass>7.51</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.60</SightsEfficiency>
+					<ShotSpread>0.04</ShotSpread>
+					<SwayFactor>1.76</SwayFactor>
+					<Bulk>9.05</Bulk>
+					<WorkToMake>37500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>10</WoodLog>
+					<Steel>60</Steel>
+					<ComponentIndustrial>7</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>68</range>
+					<soundCast>RNShotPSG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_DragunovDMR" or
+					defName="RNGun_M21DMR" or
+					defName="RNGun_WA2000DMR"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>			

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_AK_Style.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_AK_Style.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== AK-47 (Mercenary) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_AK47MercenaryAR</defName>
+				<statBases>
+					<Mass>3.47</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.23</SwayFactor>
+					<Bulk>8.80</Bulk>
+					<WorkToMake>27000</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>10</WoodLog>
+					<Steel>45</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.82</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>44</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<soundCast>RNShot_AK47Rifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Regular</recoilPattern>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNGun_AK47MercenaryAR"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_AR_Style.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_AR_Style.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== M16A1 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M16A1Bare</defName>
+				<statBases>
+					<Mass>2.89</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.29</SwayFactor>
+					<Bulk>10.03</Bulk>
+					<WorkToMake>30000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>50</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.63</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>59</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>RNShot_GenericAR_IV</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- ========== M4A1 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M4A1Bare</defName>
+				<statBases>
+					<Mass>2.90</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.1</ShotSpread>
+					<SwayFactor>1.13</SwayFactor>
+					<Bulk>7.56</Bulk>
+					<WorkToMake>32000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>40</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.58</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>RNShot_GenericAR_II</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- ========== M4A1 SD ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M4A1BareSD</defName>
+				<statBases>
+					<Mass>3.52</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.28</SwayFactor>
+					<Bulk>8.45</Bulk>
+					<WorkToMake>32500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>45</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.44</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>RNShot_SDAR_III</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_M16A1Bare" or
+					defName="RNGun_M4A1Bare" or
+					defName="RNGun_M4A1BareSD"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>			

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_Bullpup_Style.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_Bullpup_Style.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Steyr AUG A2 ========== -->		
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_AUGA2AR</defName>
+				<statBases>
+					<Mass>3.60</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.09</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.17</SwayFactor>
+					<Bulk>7.90</Bulk>
+					<WorkToMake>40500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>45</Steel>
+					<ComponentIndustrial>7</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.47</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.175</warmupTime>
+					<range>40</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>RNShotAUG</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNGun_AUGA2AR"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>			

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_Other.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_R_Other.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== FN FAL ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_FNFALAR</defName>
+				<statBases>
+					<Mass>4.30</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>1.52</SwayFactor>
+					<Bulk>10.90</Bulk>
+					<WorkToMake>30500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>55</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>2.07</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>62</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>RNShotSCARH</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- ========== FN FNC ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_FNFNCAR</defName>
+				<statBases>
+					<Mass>3.84</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.38</SwayFactor>
+					<Bulk>7.66</Bulk>
+					<WorkToMake>31500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>5</Chemfuel>
+					<Steel>50</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.42</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>48</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>RNShot_GenericBullpup_IV</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_FNFALAR" or
+					defName="RNGun_FNFNCAR"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+
+		</operations>
+	</Operation>
+</Patch>			

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Scenarios_MSF.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Scenarios_MSF.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ScenarioDef[defName="RH_Scenario_MSF"]/scenario/parts</xpath>
+				<value>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_556x45mmNATO_FMJ</thingDef>
+						<count>1000</count>
+					</li>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_762x39mmSoviet_FMJ</thingDef>
+						<count>500</count>
+					</li>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_762x54mmR_FMJ</thingDef>
+						<count>500</count>
+					</li>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_9x19mmPara_NL</thingDef>
+						<count>500</count>
+					</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_TraderKinds.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_TraderKinds.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[RH] Faction: Militaires Sans Frontieres</modName>
+			</li>
+
+			<!-- ========== Traders should also sell CE ammo ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[
+					defName="RHVisitor_MSF_Standard" or
+					defName="RHBase_MSF_Standard" or
+					defName="RHCaravan_MSF_WarMerchant"
+				]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Ammo</tradeTag>
+						<countRange>
+							<min>1000</min>
+							<max>3000</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>5</min>
+							<max>12</max>
+						</thingDefCountRange>
+					</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Patches brought over as part of the FastTrack merger, and updated to RimWorld 1.1 standards

Notes:
* Gun stats calculated using the [CE:FT Gun Stats spreadsheet](https://docs.google.com/spreadsheets/d/1Z9ZBnwRQWCKQm18O4I9ja4mFwLVChkNNfam2ZeQTTa0/edit#gid=1573763037)
* Added the following conditionally-patched mod-unique ammo:
  * 9x19mm Parabellum Tranq pistol cartridge
  * 7.62x51mm NATO Tranq rifle cartridge
  * (Ammo is shared by both mods)
* All apparel balanced to 1.6/1.8 standards
* Melee tools standardized as per generic CE weapons, with PatchOps consolidated where reasonable
* High Frequency Blade from Metal Gear Solid uses original mod capacities, but has custom CE melee sharp and blunt armor penetration values specifically tuned according to the original mod author's request
  * Specifically, the sword can down Mech Centipedes after 5~6 attacks, and Scythers in 2~3 hits