### PR TITLE
Add CP DOOM and The DOOM Kit Classic patches

### DIFF
--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_12Gauge_Dual.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_12Gauge_Dual.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[CP] DOOM</li>
+			<li>[CP] The DOOM Kit - Classic</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- ========== Custom variants of the standard 12 Gauge shotgun projectiles, emulating the effect of two ordinary 12 Gauge shotgun shells being fired side-by-side simultaneously ========== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+							<defName>Bullet_12Gauge_DoubleBarreled_Buck</defName>
+							<label>buckshot pellet</label>
+							<graphicData>
+								<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>18</damageAmountBase>
+								<pelletCount>18</pelletCount>
+								<armorPenetrationSharp>4</armorPenetrationSharp>
+								<armorPenetrationBlunt>5.7</armorPenetrationBlunt>
+								<spreadMult>17.8</spreadMult>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+							<defName>Bullet_12Gauge_DoubleBarreled_Slug</defName>
+							<label>shotgun slug</label>
+							<graphicData>
+								<texPath>Things/Projectile/Bullet_big</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>83</speed>
+								<damageAmountBase>46</damageAmountBase>
+								<armorPenetrationSharp>6</armorPenetrationSharp>
+								<armorPenetrationBlunt>48.04</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+							<defName>Bullet_12Gauge_DoubleBarreled_Beanbag</defName>
+							<label>beanbag</label>
+							<graphicData>
+								<texPath>Things/Projectile/Bullet_big</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>18</speed>
+								<damageDef>Beanbag</damageDef>
+								<damageAmountBase>18</damageAmountBase>
+								<armorPenetrationSharp>0</armorPenetrationSharp>
+								<armorPenetrationBlunt>3.240</armorPenetrationBlunt>
+								<spreadMult>2</spreadMult>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+							<defName>Bullet_12Gauge_DoubleBarreled_ElectroSlug</defName>
+							<label>EMP slug</label>
+							<graphicData>
+								<texPath>Things/Projectile/Bullet_big</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>30</speed>
+								<damageDef>EMP</damageDef>
+								<damageAmountBase>24</damageAmountBase>
+								<armorPenetrationSharp>0</armorPenetrationSharp>
+								<armorPenetrationBlunt>8.509</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<!-- ========== Custom AmmoSet for the double-barreled Super Shotgun, which maps the custom 12 Gauge shotgun projectiles to standard versions of their craftable ammo ========== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_12Gauge_CP_DOOM_SuperShotgun</defName>
+							<label>12 Gauge</label>
+							<ammoTypes>
+								<Ammo_12Gauge_Buck>Bullet_12Gauge_DoubleBarreled_Buck</Ammo_12Gauge_Buck>
+								<Ammo_12Gauge_Slug>Bullet_12Gauge_DoubleBarreled_Slug</Ammo_12Gauge_Slug>
+								<Ammo_12Gauge_Beanbag>Bullet_12Gauge_DoubleBarreled_Beanbag</Ammo_12Gauge_Beanbag>
+								<Ammo_12Gauge_ElectroSlug>Bullet_12Gauge_DoubleBarreled_ElectroSlug</Ammo_12Gauge_ElectroSlug>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_12Gauge_Dual.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_12Gauge_Dual.xml
@@ -23,7 +23,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageAmountBase>18</damageAmountBase>
-								<pelletCount>18</pelletCount>
+								<pelletCount>18</pelletCount> <!-- Twice the usual number of buckshot pellets -->
 								<armorPenetrationSharp>4</armorPenetrationSharp>
 								<armorPenetrationBlunt>5.7</armorPenetrationBlunt>
 								<spreadMult>17.8</spreadMult>
@@ -40,6 +40,7 @@
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<speed>83</speed>
 								<damageAmountBase>46</damageAmountBase>
+								<pelletCount>2</pelletCount> <!-- Double slugs -->
 								<armorPenetrationSharp>6</armorPenetrationSharp>
 								<armorPenetrationBlunt>48.04</armorPenetrationBlunt>
 							</projectile>
@@ -56,6 +57,7 @@
 								<speed>18</speed>
 								<damageDef>Beanbag</damageDef>
 								<damageAmountBase>18</damageAmountBase>
+								<pelletCount>2</pelletCount> <!-- Double beanbags -->
 								<armorPenetrationSharp>0</armorPenetrationSharp>
 								<armorPenetrationBlunt>3.240</armorPenetrationBlunt>
 								<spreadMult>2</spreadMult>
@@ -73,6 +75,7 @@
 								<speed>30</speed>
 								<damageDef>EMP</damageDef>
 								<damageAmountBase>24</damageAmountBase>
+								<pelletCount>2</pelletCount> <!-- Double EMP slugs -->
 								<armorPenetrationSharp>0</armorPenetrationSharp>
 								<armorPenetrationBlunt>8.509</armorPenetrationBlunt>
 							</projectile>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_BfgCell.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_BfgCell.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<!-- There is only one type of UAC BFG Cell for CE, no subcategory for variants required -->
+
+					<!-- ==================== AmmoSets ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016Bfg9000Gun</defName>
+						<label>UAC BFG Cell</label>
+						<ammoTypes>
+							<Ammo_Doom2016BfgCell>Bullet_Doom2016Bfg9000Gun</Ammo_Doom2016BfgCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+						<defName>Ammo_Doom2016BfgCell</defName>
+						<label>UAC BFG Cell</label>
+						<description>Plasma containment power cell developed by the Union Aerospace Corporation for the BFG 9000, utilizing the compression of Argent energy</description>
+						<statBases>
+							<Mass>0.5</Mass>
+							<Bulk>1.21</Bulk>
+							<MarketValue>31.92</MarketValue>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting_TableMachining</li>
+							<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoAdvanced</li>
+						</thingCategories>
+						<stackLimit>25</stackLimit>
+						<graphicData>
+							<texPath>ThirdParty/CP DOOM and DOOM Kit Classic/Doom2016BfgCell</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<ammoClass>Plasma</ammoClass>
+						<comps>
+							<!-- Arbitarily defined cookoff explosive stats; represents a plasma containment system failing -->
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>20</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>0.5</explosionRadius>
+								<fragments>
+									<Fragment_Large>2</Fragment_Large>
+									<Fragment_Small>10</Fragment_Small>
+								</fragments>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+					
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base6x24mmChargedBullet) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016Bfg9000Gun</defName>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<label>BFG Plasma Shot</label>
+						<graphicData>
+							<texPath>Things/Projectile/BFGPLAZMA</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>200</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>560</damageAmountBase>
+							<explosionRadius>2.5</explosionRadius>
+							<soundExplode>RHHit_DOOMBFG</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>2680</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="ChargeAmmoRecipeBase">
+						<defName>MakeAmmo_Doom2016BfgCell</defName>
+						<label>make UAC BFG Cells x25</label>
+						<description>Craft 25 UAC BFG Cells.</description>
+						<jobString>Making UAC BFG Cells.</jobString>
+						<workAmount>33000</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>26</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Plasteel</li>
+									</thingDefs>
+								</filter>
+								<count>73</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Plasteel</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Doom2016BfgCell>25</Ammo_Doom2016BfgCell>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_EmgMkVPistol.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_EmgMkVPistol.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<!-- There is only one type of UAC EMG Cell for CE, no subcategory for variants required -->
+
+					<!-- ==================== AmmoSet ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016EmgMkVPistol</defName>
+						<label>UAC EMG Cell</label>
+						<ammoTypes>
+							<Ammo_Doom2016EmgMkVPistol>Bullet_Doom2016EmgMkVPistol</Ammo_Doom2016EmgMkVPistol>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+						<defName>Ammo_Doom2016EmgMkVPistol</defName>
+						<label>UAC EMG Cell</label>
+						<description>Plasma containment power cell developed by the Union Aerospace Corporation for directed-energy sidearms, utilizing the compression of Argent energy into a kinetic slug</description>
+						<statBases>
+							<Mass>0.004</Mass>
+							<Bulk>0.01</Bulk>
+							<MarketValue>0.21</MarketValue>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting_TableMachining</li>
+							<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoAdvanced</li>
+						</thingCategories>
+						<graphicData>
+							<texPath>Things/Ammo/Charged/Concentrated</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+						</graphicData>
+						<ammoClass>Plasma</ammoClass>
+						<comps>
+							<!-- Arbitarily defined cookoff explosive stats; represents a plasma containment system failing -->
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>20</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>0.5</explosionRadius>
+								<fragments>
+									<Fragment_Large>2</Fragment_Large>
+									<Fragment_Small>10</Fragment_Small>
+								</fragments>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+					
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base6x24mmChargedBullet) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016EmgMkVPistol</defName>
+						<label>EMG Bolt</label>
+						<graphicData>
+							<texPath>Things/Projectile/EMGMarkV</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>140</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>3</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>12</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="ChargeAmmoRecipeBase">
+						<defName>MakeAmmo_Doom2016EmgMkVPistol</defName>
+						<label>make UAC EMG Cells</label>
+						<description>Craft 500 shots' worth of UAC EMG Cells.</description>
+						<jobString>Making UAC EMG Cells.</jobString>
+						<workAmount>2800</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>4</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Plasteel</li>
+									</thingDefs>
+								</filter>
+								<count>3</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Plasteel</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Doom2016EmgMkVPistol>500</Ammo_Doom2016EmgMkVPistol>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_EmgPistol.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_EmgPistol.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<!-- Projectile-only definition for the weaker infinite-ammo EMG Pistol; uses same stats as the generic Plasma Pistol projectile -->
+
+					<!-- ================== Projectiles ================== -->
+					
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base6x24mmChargedBullet) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016EmgPistol</defName>
+						<label>EMG Bolt</label>
+						<graphicData>
+							<texPath>Things/Projectile/UACSidearmProj</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>140</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>2</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>9</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_GaussCannonFlechette.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_GaussCannonFlechette.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<!-- DOOM 2016 specifies that the Guass Cannon uses Plasma Cells as ammo, but fires steel (railgun) flechettes instead -->
+
+					<!-- ==================== AmmoSets ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016GaussCannon</defName>
+						<label>UAC Plasma Cell</label>
+						<ammoTypes>
+							<Ammo_Doom2016PlasmaCell>Bullet_Doom2016GaussCannonFlechette</Ammo_Doom2016PlasmaCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ================== Projectiles ================== -->
+
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base6x24mmChargedBullet) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016GaussCannonFlechette</defName>
+						<label>UAC Gauss Cannon Flechette</label>
+						<graphicData>
+							<texPath>Things/Projectile/GAUSSBeam</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bullet</damageDef>
+							<damageAmountBase>121</damageAmountBase>
+							<armorPenetrationSharp>160</armorPenetrationSharp>
+							<armorPenetrationBlunt>11348.10</armorPenetrationBlunt>
+							<speed>500</speed>
+						</projectile>
+					</ThingDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_PlasmaCell.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_PlasmaCell.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<!-- There is only one type of UAC Plasma Cell for CE, no subcategory for variants required -->
+
+					<!-- ==================== AmmoSets ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016PlasmaGun</defName>
+						<label>UAC Plasma Cell</label>
+						<ammoTypes>
+							<Ammo_Doom2016PlasmaCell>Bullet_Doom2016PlasmaGun</Ammo_Doom2016PlasmaCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016VortexRifle</defName>
+						<label>UAC Plasma Cell</label>
+						<ammoTypes>
+							<Ammo_Doom2016PlasmaCell>Bullet_Doom2016VortexRifle</Ammo_Doom2016PlasmaCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016Hellshot</defName>
+						<label>UAC Plasma Cell</label>
+						<ammoTypes>
+							<Ammo_Doom2016PlasmaCell>Bullet_Doom2016Hellshot</Ammo_Doom2016PlasmaCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+						<defName>Ammo_Doom2016PlasmaCell</defName>
+						<label>UAC Plasma Cell</label>
+						<description>Plasma containment power cell developed by the Union Aerospace Corporation for heavy energy weapons, utilizing the compression of Argent energy</description>
+						<statBases>
+							<Mass>0.002</Mass>
+							<Bulk>0.01</Bulk>
+							<MarketValue>0.84</MarketValue>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting_TableMachining</li>
+							<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoAdvanced</li>
+						</thingCategories>
+						<stackLimit>450</stackLimit>
+						<graphicData>
+							<texPath>ThirdParty/CP DOOM and DOOM Kit Classic/Doom2016PlasmaCell</texPath>
+							<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+						</graphicData>
+						<ammoClass>Plasma</ammoClass>
+						<comps>
+							<!-- Arbitarily defined cookoff explosive stats; represents a plasma containment system failing -->
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>80</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>0.5</explosionRadius>
+								<fragments>
+									<Fragment_Large>2</Fragment_Large>
+									<Fragment_Small>10</Fragment_Small>
+								</fragments>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base6x24mmChargedBullet) -->
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016PlasmaGun</defName>
+						<label>Plasma Shot</label>
+						<graphicData>
+							<texPath>Things/Projectile/Plasma2016</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>200</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>14</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>67</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016VortexRifle</defName>
+						<label>Plasma Shot</label>
+						<graphicData>
+							<texPath>Things/Projectile/Vortexbeam</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>200</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>14</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>67</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_Doom2016Hellshot</defName>
+						<label>Plasma Shot</label>
+						<graphicData>
+							<texPath>Things/Projectile/HellshotPlasma</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>200</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>14</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>67</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="ChargeAmmoRecipeBase">
+						<defName>MakeAmmo_Doom2016PlasmaCell</defName>
+						<label>make UAC Plasma Cells x450 shots</label>
+						<description>Craft 450 shots' worth of UAC Plasma Cells.</description>
+						<jobString>Making UAC Plasma Cells.</jobString>
+						<workAmount>14600</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Plasteel</li>
+									</thingDefs>
+								</filter>
+								<count>33</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Plasteel</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Doom2016PlasmaCell>450</Ammo_Doom2016PlasmaCell>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_Rocket.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_Rocket.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<ThingCategoryDef>
+						<defName>AmmoDoom2016Rockets</defName>
+						<label>UAC Rocket Mk VI</label>
+						<parent>AmmoRockets</parent>
+						<iconPath>ThirdParty/CP DOOM and DOOM Kit Classic/Doom2016Rocket/Doom2016Rocket_c</iconPath>
+					</ThingCategoryDef>
+
+					<!-- ==================== AmmoSet ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_Doom2016Rocket</defName>
+						<label>UAC Rocket Mk VI</label>
+						<ammoTypes>
+							<Ammo_Doom2016Rocket_HEAT>Bullet_Doom2016Rocket_HEAT</Ammo_Doom2016Rocket_HEAT>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" Name="Doom2016RocketBase" ParentName="AmmoBase" Abstract="True">
+						<description>Compact 60mm rocket developed by the Union Aerospace Corporation for infantry rocket launchers.</description>
+						<statBases>
+							<MaxHitPoints>150</MaxHitPoints>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting_TableMachining</li>
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoDoom2016Rockets</li>
+						</thingCategories>
+						<stackLimit>9</stackLimit>
+						<cookOffFlashScale>40</cookOffFlashScale>
+						<cookOffSound>MortarBomb_Explode</cookOffSound>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Doom2016RocketBase">
+						<defName>Ammo_Doom2016Rocket_HEAT</defName>
+						<label>UAC Rocket Mk VI (HEAT)</label>
+						<graphicData>
+							<texPath>ThirdParty/CP DOOM and DOOM Kit Classic/Doom2016Rocket</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+						</graphicData>
+						<statBases>
+							<MarketValue>24.42</MarketValue>
+							<Mass>0.75</Mass>
+							<Bulk>1.53</Bulk>
+						</statBases>
+						<ammoClass>RocketHEAT</ammoClass>
+						<comps>
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>64</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>1</explosionRadius>
+								<fragments>
+									<Fragment_Large>1</Fragment_Large>
+									<Fragment_Small>12</Fragment_Small>
+								</fragments>
+								<soundExplode>MortarBomb_Explode</soundExplode>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+					
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, BaseM6Rocket) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseM6Rocket">
+						<defName>Bullet_Doom2016Rocket_HEAT</defName>
+						<label>UAC Rocket Mk VI (HEAT)</label>
+						<graphicData>
+							<texPath>Things/Projectile/UACRocket2016</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bullet</damageDef>
+							<damageAmountBase>225</damageAmountBase>
+							<armorPenetrationSharp>76</armorPenetrationSharp>
+							<armorPenetrationBlunt>19.178</armorPenetrationBlunt>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>64</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>1</explosionRadius>
+								<fragments>
+									<Fragment_Large>1</Fragment_Large>
+									<Fragment_Small>12</Fragment_Small>
+								</fragments>
+								<soundExplode>RHHit_DOOMRocketLauncher</soundExplode>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_Doom2016Rocket_HEAT</defName>
+						<label>make UAC Rocket Mk VI (HEAT) rockets x9</label>
+						<description>Craft 9 UAC Rocket Mk VI (HEAT) rockets.</description>
+						<jobString>Making UAC Rocket Mk VI (HEAT) rockets.</jobString>
+						<workAmount>6200</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>14</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>FSX</li>
+									</thingDefs>
+								</filter>
+								<count>6</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>4</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>FSX</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_Doom2016Rocket_HEAT>9</Ammo_Doom2016Rocket_HEAT>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Apparel_Armor.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Apparel_Armor.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<!-- ========== Praetor Suit ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>40</CarryBulk>
+					<CarryWeight>90</CarryWeight>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>1.0</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/statBases</xpath>
+				<value>
+					<ArmorRating_Electric>0.975</ArmorRating_Electric>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Apparel_Armor_Headgear.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<!-- ========== Praetor Suit helmet ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>1.0</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/statBases</xpath>
+				<value>
+					<ArmorRating_Electric>0.975</ArmorRating_Electric>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<!-- WearingGasMask Hediff not applicable -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_BaseWeapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_BaseWeapons.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<!-- ==================== Weapons research prerequisite patches ==================== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="DOOMMakeableLauncher"]/recipeMaker/researchPrerequisite[text()="MultibarrelWeapons"]</xpath>
+				<value>
+					<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					@Name="DOOMMakeableGun" or
+					defName="RHGun_DOOM_Chaingun"
+				]/recipeMaker/researchPrerequisite[text()="MultibarrelWeapons"]</xpath>
+				<value>
+					<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_LauncherDOOM_Weapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_LauncherDOOM_Weapons.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<!-- ========== UAC Gauss Cannon ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHEx_DOOM_GAUSSCannon</defName>
+				<statBases>
+					<Mass>12.50</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.20</SightsEfficiency>
+					<ShotSpread>0.04</ShotSpread>
+					<SwayFactor>1.78</SwayFactor>
+					<Bulk>15.63</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016GaussCannonFlechette</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<ammoConsumedPerShotCount>30</ammoConsumedPerShotCount>
+					<range>126</range>
+					<soundCast>RHShot_DOOMGAUSS</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>15</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>150</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_Doom2016GaussCannon</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== BFG 9000 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHEx_DOOM_BFG9000Gun</defName>
+				<statBases>
+					<Mass>10.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>0.88</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016Bfg9000Gun</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<soundAiming>RHGun_DOOMBFGAiming</soundAiming>
+					<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+					<range>62</range>
+					<soundCast>RHShot_DOOMBFG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>false</onlyManualCast>
+					<muzzleFlashScale>20</muzzleFlashScale>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>3</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_Doom2016Bfg9000Gun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC Rocket Launcher ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHEx_DOOM_RocketLauncher</defName>
+				<statBases>
+					<Mass>8.00</Mass>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1.82</SwayFactor>
+					<Bulk>11.20</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016Rocket_HEAT</defaultProjectile>
+					<warmupTime>1.9</warmupTime>
+					<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+					<range>40</range>
+					<soundCast>RHShot_DOOMRocketLauncher</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>5.1</reloadTime>
+					<ammoSet>AmmoSet_Doom2016Rocket</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+			</li>
+
+			<!-- ========== UAC Grenade Launcher ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHEx_UACGrenadeLauncher</defName>
+				<statBases>
+					<Mass>5.30</Mass>
+					<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.18</ShotSpread>
+					<SwayFactor>1.31</SwayFactor>
+					<Bulk>7.67</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>40</range>
+					<soundCast>RHShot_DOOMGrenadeLauncher</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>5.1</reloadTime>
+					<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHEx_DOOM_GAUSSCannon" or
+					defName="RHEx_UACGrenadeLauncher"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHEx_DOOM_BFG9000Gun" or
+					defName="RHEx_DOOM_RocketLauncher"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>2.44</cooldownTime>
+							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_MeleeDOOM_Weapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_MeleeDOOM_Weapons.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<!-- ========== Mixom Beavertooth Painsaw (chainsaw) ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHMelee_DOOM_Chainsaw"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>RHMelee_ChainsawSlash</li>
+							</capacities>
+							<power>38</power>
+							<cooldownTime>4.36</cooldownTime>
+							<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
+							<armorPenetrationSharp>14.8</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>RHMelee_ChainsawStab</li>
+							</capacities>
+							<power>40</power>
+							<cooldownTime>2.47</cooldownTime>
+							<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.65</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHMelee_DOOM_Chainsaw"]/statBases</xpath>
+				<value>
+					<Bulk>9</Bulk>
+					<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHMelee_DOOM_Chainsaw"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.04</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_RangedDOOM_Weapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_RangedDOOM_Weapons.xml
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] DOOM</modName>
+			</li>
+
+			<!-- ========== UAC EMG Sidearm ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_UACEMGPistol</defName>
+				<statBases>
+					<Mass>1.35</Mass>
+					<RangedWeapon_Cooldown>0.05</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.176</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>2.45</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016EmgPistol</defaultProjectile>
+					<warmupTime>0.0</warmupTime>
+					<range>12</range>
+					<soundCast>RHShot_DOOMEMGPistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<!-- Infinite ammo -->
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+
+			</li>
+
+			<!-- ========== UAC EMG Mk V Pistol ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_UACEMGMarkVPistol</defName>
+				<statBases>
+					<Mass>1.35</Mass>
+					<RangedWeapon_Cooldown>0.05</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.176</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>2.45</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016EmgMkVPistol</defaultProjectile>
+					<warmupTime>0.0</warmupTime>
+					<range>12</range>
+					<soundCast>RHShot_DOOMEMGMarkVPistol</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>50</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_Doom2016EmgMkVPistol</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC Combat Shotgun ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_CombatShotgun</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.14</ShotSpread>
+					<SwayFactor>1.49</SwayFactor>
+					<Bulk>7.67</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.26</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>20</range>
+					<soundCast>RHShot_DOOMCombatShotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_12Gauge</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+
+			</li>
+
+			<!-- ========== Super Shotgun ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_SuperShotgun</defName>
+				<statBases>
+					<Mass>1.90</Mass>
+					<RangedWeapon_Cooldown>0.93</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>2.73</SwayFactor>
+					<Bulk>6.29</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_DoubleBarreled_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
+					<range>11</range>
+					<soundCast>RHShot_DOOMSuperShotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>2</magazineSize>
+					<reloadTime>1.7</reloadTime>
+					<ammoSet>AmmoSet_12Gauge_CP_DOOM_SuperShotgun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC Heavy Assault Rifle ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_HeavyAssaultRifle</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>9.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.48</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<range>75</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<burstShotCount>6</burstShotCount>
+					<soundCast>RHShot_DOOMHeavyAssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>90</magazineSize>
+					<reloadTime>7.80</reloadTime>
+					<ammoSet>AmmoSet_50BMG</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC D12 Chaingun ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_Chaingun</defName>
+				<statBases>
+					<Mass>39.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>1.32</SwayFactor>
+					<Bulk>9.5</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.58</recoilAmount>
+					<recoilPattern>Mounted</recoilPattern>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+					<warmupTime>2.3</warmupTime>
+					<range>62</range>
+					<burstShotCount>150</burstShotCount>
+					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+					<soundCast>RHFire_DOOMChaingun</soundCast>
+					<soundAiming>RHGun_DOOMChaingunAiming</soundAiming>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>150</magazineSize>
+					<reloadTime>9.2</reloadTime>
+					<ammoSet>AmmoSet_50BMG</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC Plasma Rifle ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_PlasmaRifle</defName>
+				<statBases>
+					<Mass>8.20</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.48</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016PlasmaGun</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<range>75</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>RHShot_DOOMPlasmaRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>150</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_Doom2016PlasmaGun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC Plasma Gun ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_PlasmaGun</defName>
+				<statBases>
+					<Mass>8.20</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.48</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016PlasmaGun</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<range>75</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>RHShot_DOOMPlasmaGun</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>150</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_Doom2016PlasmaGun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<!-- ========== UAC Vortex Rifle ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_VortexRifle</defName>
+				<statBases>
+					<Mass>7.51</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.60</SightsEfficiency>
+					<ShotSpread>0.04</ShotSpread>
+					<SwayFactor>1.76</SwayFactor>
+					<Bulk>9.05</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016VortexRifle</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>68</range>
+					<soundCast>RHFire_DOOMVortexRifle</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_Doom2016VortexRifle</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== UAC Hellshot ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOM_Hellshot</defName>
+				<statBases>
+					<Mass>6.35</Mass>
+					<RangedWeapon_Cooldown>0.05</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.24</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1.42</SwayFactor>
+					<Bulk>7.49</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Doom2016Hellshot</defaultProjectile>
+					<warmupTime>0.0</warmupTime>
+					<range>48</range>
+					<soundCast>RHFire_DOOMHellshot</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>60</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_Doom2016Hellshot</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHGun_DOOM_UACEMGPistol" or
+					defName="RHGun_DOOM_UACEMGMarkVPistol"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHGun_DOOM_CombatShotgun" or
+					defName="RHGun_DOOM_SuperShotgun" or
+					defName="RHGun_DOOM_HeavyAssaultRifle" or
+					defName="RHGun_DOOM_PlasmaRifle" or
+					defName="RHGun_DOOM_PlasmaGun" or
+					defName="RHGun_DOOM_VortexRifle" or
+					defName="RHGun_DOOM_Hellshot"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHGun_DOOM_Chaingun"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>2.44</cooldownTime>
+							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicEnergyCell.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicEnergyCell.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<!-- There is only one type of UAC Energy Cell for CE, no subcategory for variants required -->
+
+					<!-- ==================== AmmoSets ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_DoomClassicPlasmaGun</defName>
+						<label>UAC Energy Cell</label>
+						<ammoTypes>
+							<Ammo_DoomClassicEnergyCell>Bullet_DoomClassicPlasmaGun</Ammo_DoomClassicEnergyCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_DoomClassicBfg9000Gun</defName>
+						<label>UAC Energy Cell</label>
+						<ammoTypes>
+							<Ammo_DoomClassicEnergyCell>Bullet_DoomClassicBfg9000Gun</Ammo_DoomClassicEnergyCell>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+						<defName>Ammo_DoomClassicEnergyCell</defName>
+						<label>UAC Energy Cell</label>
+						<description>Plasma containment power cell developed by the Union Aerospace Corporation for experimental energy weapons</description>
+						<statBases>
+							<Mass>0.013</Mass>
+							<Bulk>0.03</Bulk>
+							<MarketValue>1.48</MarketValue>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting_TableMachining</li>
+							<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoAdvanced</li>
+						</thingCategories>
+						<stackLimit>100</stackLimit>
+						<graphicData>
+							<texPath>ThirdParty/CP DOOM and DOOM Kit Classic/DoomClassicEnergyCell</texPath>
+							<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+						</graphicData>
+						<ammoClass>Plasma</ammoClass>
+						<comps>
+							<!-- Arbitarily defined cookoff explosive stats; represents a plasma containment system failing -->
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>20</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>0.5</explosionRadius>
+								<fragments>
+									<Fragment_Large>2</Fragment_Large>
+									<Fragment_Small>10</Fragment_Small>
+								</fragments>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+					
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base6x24mmChargedBullet) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_DoomClassicPlasmaGun</defName>
+						<label>Plasma Shot</label>
+						<graphicData>
+							<texPath>Things/Projectile/Plasma_Classic</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>200</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>14</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>67</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_DoomClassicBfg9000Gun</defName>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<label>BFG Plasma Shot</label>
+						<graphicData>
+							<texPath>Things/Projectile/BFGPLAZMA</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>200</speed>
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>560</damageAmountBase>
+							<explosionRadius>2.5</explosionRadius>
+							<soundExplode>RHHit_DOOMClassicBFG</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<secondaryDamage>
+								<li>
+									<def>Flame_Secondary</def>
+									<amount>2680</amount>
+								</li>
+							</secondaryDamage>
+						</projectile>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="ChargeAmmoRecipeBase">
+						<defName>MakeAmmo_DoomClassicEnergyCell</defName>
+						<label>make UAC Energy Cells x100 shots</label>
+						<description>Craft 100 shots' worth of UAC Energy Cells.</description>
+						<jobString>Making UAC Energy Cells.</jobString>
+						<workAmount>4800</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>4</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Plasteel</li>
+									</thingDefs>
+								</filter>
+								<count>8</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Plasteel</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_DoomClassicEnergyCell>100</Ammo_DoomClassicEnergyCell>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicRocket.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicRocket.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<ThingCategoryDef>
+						<defName>AmmoDoomClassicRockets</defName>
+						<label>UAC Rocket Mk I</label>
+						<parent>AmmoRockets</parent>
+						<iconPath>ThirdParty/CP DOOM and DOOM Kit Classic/DoomClassicRocket/DoomClassicRocket_c</iconPath>
+					</ThingCategoryDef>
+
+					<!-- ==================== AmmoSet ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_DoomClassicRocket</defName>
+						<label>UAC Rocket Mk I</label>
+						<ammoTypes>
+							<Ammo_DoomClassicRocket_HEAT>Bullet_DoomClassicRocket_HEAT</Ammo_DoomClassicRocket_HEAT>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" Name="DoomClassicRocketBase" ParentName="AmmoBase" Abstract="True">
+						<description>Compact 60mm rocket developed by the Union Aerospace Corporation for infantry rocket launchers.</description>
+						<statBases>
+							<MaxHitPoints>150</MaxHitPoints>
+						</statBases>
+						<tradeTags>
+							<li>CE_AutoEnableTrade</li>
+							<li>CE_AutoEnableCrafting_TableMachining</li>
+						</tradeTags>
+						<thingCategories>
+							<li>AmmoDoomClassicRockets</li>
+						</thingCategories>
+						<stackLimit>5</stackLimit>
+						<cookOffFlashScale>40</cookOffFlashScale>
+						<cookOffSound>MortarBomb_Explode</cookOffSound>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="DoomClassicRocketBase">
+						<defName>Ammo_DoomClassicRocket_HEAT</defName>
+						<label>UAC Rocket Mk I (HEAT)</label>
+						<graphicData>
+							<texPath>ThirdParty/CP DOOM and DOOM Kit Classic/DoomClassicRocket</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+						</graphicData>
+						<statBases>
+							<MarketValue>37.44</MarketValue>
+							<Mass>0.75</Mass>
+							<Bulk>1.53</Bulk>
+						</statBases>
+						<ammoClass>RocketHEAT</ammoClass>
+						<comps>
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>64</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>1</explosionRadius>
+								<fragments>
+									<Fragment_Large>1</Fragment_Large>
+									<Fragment_Small>12</Fragment_Small>
+								</fragments>
+								<soundExplode>MortarBomb_Explode</soundExplode>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+
+					<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, BaseM6Rocket) -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseM6Rocket">
+						<defName>Bullet_DoomClassicRocket_HEAT</defName>
+						<label>UAC Rocket Mk I (HEAT)</label>
+						<graphicData>
+							<texPath>Things/Projectile/DOOM_Rocket</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>60</speed>
+							<damageDef>Bullet</damageDef>
+							<damageAmountBase>225</damageAmountBase>
+							<armorPenetrationSharp>76</armorPenetrationSharp>
+							<armorPenetrationBlunt>19.178</armorPenetrationBlunt>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<explosionDamage>64</explosionDamage>
+								<explosionDamageDef>Bomb</explosionDamageDef>
+								<explosionRadius>1</explosionRadius>
+								<fragments>
+									<Fragment_Large>1</Fragment_Large>
+									<Fragment_Small>12</Fragment_Small>
+								</fragments>
+								<soundExplode>RHHit_DOOMClassicRocketLauncher</soundExplode>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<!-- ==================== Recipes ========================== -->
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_DoomClassicRocket_HEAT</defName>
+						<label>make UAC Rocket Mk I (HEAT) rockets x5</label>
+						<description>Craft 5 UAC Rocket Mk I (HEAT) rockets.</description>
+						<jobString>Making UAC Rocket Mk I (HEAT) rockets.</jobString>
+						<workAmount>4800</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>8</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>FSX</li>
+									</thingDefs>
+								</filter>
+								<count>4</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>4</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>FSX</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_DoomClassicRocket_HEAT>5</Ammo_DoomClassicRocket_HEAT>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Apparel_Armor.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Apparel_Armor.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<!-- ========== Praetor Suit (classic) ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>40</CarryBulk>
+					<CarryWeight>90</CarryWeight>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>1.0</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/statBases</xpath>
+				<value>
+					<ArmorRating_Electric>0.975</ArmorRating_Electric>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Apparel_Armor_Headgear.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<!-- ========== Praetor Suit helmet (classic) ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>1.0</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/statBases</xpath>
+				<value>
+					<ArmorRating_Electric>0.975</ArmorRating_Electric>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<!-- WearingGasMask Hediff not applicable -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+			<!-- ========== Security Helmet (DOOM) ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/statBases/ArmorRating_Heat</xpath>
+				<value>
+					<ArmorRating_Heat>0.76</ArmorRating_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/statBases</xpath>
+				<value>
+					<ArmorRating_Electric>0.75</ArmorRating_Electric>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_BaseWeapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_BaseWeapons.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<!-- ==================== Weapons research prerequisite patches ==================== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="DOOMMakeableLauncher"]/recipeMaker/researchPrerequisite[text()="MultibarrelWeapons"]</xpath>
+				<value>
+					<researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					@Name="DOOMMakeableGun" or
+					defName="RHGun_DOOMClassic_Chaingun"
+				]/recipeMaker/researchPrerequisite[text()="MultibarrelWeapons"]</xpath>
+				<value>
+					<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_LauncherDOOM_Weapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_LauncherDOOM_Weapons.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<!-- ========== BFG 9000 (DOOM) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHEx_DOOMClassic_BFG9000Gun</defName>
+				<statBases>
+					<Mass>10.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>0.88</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_DoomClassicBfg9000Gun</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<ammoConsumedPerShotCount>40</ammoConsumedPerShotCount>
+					<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+					<range>62</range>
+					<soundCast>RHShot_DOOMClassicBFG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<muzzleFlashScale>20</muzzleFlashScale>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>40</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_DoomClassicBfg9000Gun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+		
+			<!-- ========== Rocket Launcher (DOOM) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHEx_DOOMClassic_RocketLauncher</defName>
+				<statBases>
+					<Mass>8.00</Mass>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1.82</SwayFactor>
+					<Bulk>11.20</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_DoomClassicRocket_HEAT</defaultProjectile>
+					<warmupTime>1.9</warmupTime>
+					<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+					<range>40</range>
+					<soundCast>RHShot_DOOMClassicRocketLauncher</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<reloadTime>5.1</reloadTime>
+					<ammoSet>AmmoSet_DoomClassicRocket</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHEx_DOOMClassic_BFG9000Gun" or
+					defName="RHEx_DOOMClassic_RocketLauncher"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>2.44</cooldownTime>
+							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_MeleeDOOM_Weapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_MeleeDOOM_Weapons.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<!-- ========== Mixom Beavertooth Painsaw (chainsaw) ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHMelee_DOOMClassic_Chainsaw"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>RHMelee_ClassicChainsawSlash</li>
+							</capacities>
+							<power>38</power>
+							<cooldownTime>4.36</cooldownTime>
+							<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
+							<armorPenetrationSharp>14.8</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>RHMelee_ClassicChainsawStab</li>
+							</capacities>
+							<power>40</power>
+							<cooldownTime>2.47</cooldownTime>
+							<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.65</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHMelee_DOOMClassic_Chainsaw"]/statBases</xpath>
+				<value>
+					<Bulk>9</Bulk>
+					<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RHMelee_DOOMClassic_Chainsaw"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.04</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_RangedDOOM_Weapons.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_RangedDOOM_Weapons.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>[CP] The DOOM Kit - Classic</modName>
+			</li>
+
+			<!-- ========== Pistol (DOOM) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_DOOMClassic_Pistol</defName>
+				<statBases>
+					<Mass>0.97</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>1.05</SwayFactor>
+					<Bulk>2.17</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>RHShot_DOOMClassic_Pistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>15</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== Shotgun (DOOM) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOMClassic_Shotgun</defName>
+				<statBases>
+					<Mass>3.40</Mass>
+					<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.11</ShotSpread>
+					<SwayFactor>1.55</SwayFactor>
+					<Bulk>12.07</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>RHShot_DOOMClassicShotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>8</magazineSize>
+					<reloadTime>5.1</reloadTime>
+					<ammoSet>AmmoSet_12Gauge</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== Super Shotgun (DOOM) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOMClassic_SuperShotgun</defName>
+				<statBases>
+					<Mass>1.90</Mass>
+					<RangedWeapon_Cooldown>0.93</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>2.73</SwayFactor>
+					<Bulk>6.29</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_DoubleBarreled_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
+					<range>11</range>
+					<soundCast>RHShot_DOOMClassicSuperShotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>2</magazineSize>
+					<reloadTime>1.7</reloadTime>
+					<ammoSet>AmmoSet_12Gauge_CP_DOOM_SuperShotgun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+
+			<!-- ========== Chaingun (DOOM) ========== -->
+			<!-- Note: In-game lore explicitly states that the chaingun uses the same ammo as the pistol -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOMClassic_Chaingun</defName>
+				<statBases>
+					<Mass>39.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>1.32</SwayFactor>
+					<Bulk>8.02</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.58</recoilAmount>
+					<recoilPattern>Mounted</recoilPattern>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<warmupTime>2.3</warmupTime>
+					<range>62</range>
+					<burstShotCount>200</burstShotCount>
+					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+					<soundCast>RHShot_DOOMClassic_Pistol</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>200</magazineSize>
+					<reloadTime>9.2</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RHGun_DOOMClassic_Chaingun"]/description</xpath>
+				<value>
+					<description>The chaingun (also known as "gatling gun") is a rapid-firing, multi-barrelled automatic weapon that uses the same ammunition as the pistol. A high velocity heavy weapon capable of suppressing multiple targets at once.</description>
+				</value>
+			</li>
+
+			<!-- ========== Plasma Gun (DOOM) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RHGun_DOOMClassic_PlasmaGun</defName>
+				<statBases>
+					<Mass>8.20</Mass>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.27</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.48</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_DoomClassicPlasmaGun</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<range>75</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>RHShot_DOOMClassicPlasmaGun</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>40</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_DoomClassicPlasmaGun</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RNGun_DOOMClassic_Pistol"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHGun_DOOMClassic_Shotgun" or
+					defName="RHGun_DOOMClassic_SuperShotgun" or
+					defName="RHGun_DOOMClassic_PlasmaGun"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RHGun_DOOMClassic_Chaingun"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>2.44</cooldownTime>
+							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Patches brought over as part of the FastTrack merger, and updated to RimWorld 1.1 standards

Notes:
* Gun stats based on extrapolation of real-life weapons, using the [CE:FT Gun Stats spreadsheet](https://docs.google.com/spreadsheets/d/1Z9ZBnwRQWCKQm18O4I9ja4mFwLVChkNNfam2ZeQTTa0/edit#gid=1573763037)
* Added the following conditionally-patched mod-unique ammo:
  * 12 Gauge shotgun shell projectile variants (for simultaneous-firing double-barrel shotgun)
  * UAC BFG Cell (Doom 2016)
  * UAC EMG Pistol Mk V Cell (Doom 2016)
  * UAC Plasma Cell (Doom 2016)
  * UAC Rocket Mk VI (Doom 2016)
  * UAC Energy Cell (Doom Classic)
  * UAC Rocket Mk I (Doom Classic)
* All armor balanced to 1.6/1.8 standards, with respect to performance from original DOOM games
* Melee tools standardized as per generic CE weapons, with PatchOps consolidated where reasonable