### PR TITLE
Rebalance and optimize Chicken Plucker mod patches

### DIFF
--- a/Patches/CP British Military Kit/CP_BMK_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/CP British Military Kit/CP_BMK_CE_Patch_Apparel_Armor_Headgear.xml
@@ -68,10 +68,19 @@
 				</value>
 			</li>
 
-			<!-- ========== VIRTUS helmet ========== -->
+			<!-- ========== VIRTUS helmet (standard, goggle up, goggle down, masked, full masked, GSR gasmask, para, marine variants) ========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_VIRTUSHelmet" or
+					defName="RNApparel_VIRTUSHelmet_GoggleUp" or
+					defName="RNApparel_VIRTUSHelmet_GoggleDown" or
+					defName="RNApparel_VIRTUSHelmet_Masked" or
+					defName="RNApparel_VIRTUSHelmet_FullMasked" or
+					defName="RNApparel_VIRTUSHelmet_GSRGasmask" or
+					defName="RNApparel_VIRTUSHelmet_Scrim" or
+					defName="RNApparel_VIRTUSHelmet_CamCream"
+				]/statBases</xpath>
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>1</WornBulk>
@@ -82,107 +91,16 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>  
-
-			<!-- ========== VIRTUS helmet (goggle up) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GoggleUp"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GoggleUp"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>  
-
-			<!-- ========== VIRTUS helmet (goggle down) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GoggleDown"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GoggleDown"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>  
-
-			<!-- ========== VIRTUS helmet (masked) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_Masked"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_Masked"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>  
-
-			<!-- ========== VIRTUS helmet (full masked) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_FullMasked"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_FullMasked"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== VIRTUS helmet (GSR gasmask) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GSRGasmask"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GSRGasmask"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_VIRTUSHelmet" or
+					defName="RNApparel_VIRTUSHelmet_GoggleUp" or
+					defName="RNApparel_VIRTUSHelmet_GoggleDown" or
+					defName="RNApparel_VIRTUSHelmet_Masked" or
+					defName="RNApparel_VIRTUSHelmet_FullMasked" or
+					defName="RNApparel_VIRTUSHelmet_GSRGasmask" or
+					defName="RNApparel_VIRTUSHelmet_Scrim" or
+					defName="RNApparel_VIRTUSHelmet_CamCream"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
 				</value>
@@ -194,60 +112,24 @@
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>
-		
+
 			<li Class="PatchOperationAddModExtension">
 				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_GSRGasmask"]</xpath>
 				<value>
 					<li Class="CombatExtended.ApparelHediffExtension">
-							<hediff>WearingGasMask</hediff>
-						</li>
+						<hediff>WearingGasMask</hediff>
+					</li>
 				</value>
 			</li>
 
-			<!-- ========== VIRTUS helmet (Para) ========== -->
+			<!-- ========== FAST helmet UKSF (A, B, C variants) ========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_Scrim"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_Scrim"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== VIRTUS helmet (Marine) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_CamCream"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_VIRTUSHelmet_CamCream"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== FAST helmet UKSF A ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetUKSF_A"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_FASTHelmetUKSF_A" or
+					defName="RNApparel_FASTHelmetUKSF_B" or
+					defName="RNApparel_FASTHelmetUKSF_C"
+				]/statBases</xpath>
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>1</WornBulk>
@@ -258,47 +140,11 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetUKSF_A"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== FAST helmet UKSF B ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetUKSF_B"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>7</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetUKSF_B"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== FAST helmet UKSF C ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetUKSF_C"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>7</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetUKSF_C"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_FASTHelmetUKSF_A" or
+					defName="RNApparel_FASTHelmetUKSF_B" or
+					defName="RNApparel_FASTHelmetUKSF_C"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
 				</value>

--- a/Patches/CP Military Furniture/CP_MilitaryFurniture_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/CP Military Furniture/CP_MilitaryFurniture_CE_Patch_Apparel_OnSkin.xml
@@ -29,8 +29,8 @@
 					defName="RNApparel_combats_SmockHRT"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/CP Spec Ops The Line/CP_SOTL_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/CP Spec Ops The Line/CP_SOTL_CE_Patch_Apparel_Headgear.xml
@@ -11,16 +11,24 @@
 			<!-- ========== Shemagh scarf (Walker) & Shemagh mask (Walker) ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RHApparel_Shemagh_Scarf_Delta" or defName="RHApparel_Shemagh_Mask_Delta"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RHApparel_Shemagh_Scarf_Delta" or 
+					defName="RHApparel_Shemagh_Mask_Delta"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
-			<!-- ========== Baseball Cap Backwards (Delta) ========== -->
+			<!-- ========== Baseball Cap Backwards (Delta), Baseball Cap (Lugo), Boonie Hat A-TACS AU (Delta) ========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RHApparel_BackwardsCap_ATACSAU_Delta"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RHApparel_BackwardsCap_ATACSAU_Delta" or
+					defName="RHApparel_LugoCap" or
+					defName="RHApparel_ATACSAUBoonie_Delta"
+				]/statBases</xpath>
 				<value>
 					<Bulk>1</Bulk>
 					<WornBulk>1</WornBulk>
@@ -28,43 +36,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RHApparel_BackwardsCap_ATACSAU_Delta"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RHApparel_BackwardsCap_ATACSAU_Delta" or
+					defName="RHApparel_LugoCap" or
+					defName="RHApparel_ATACSAUBoonie_Delta"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== Baseball Cap (Lugo) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RHApparel_LugoCap"]/statBases</xpath>
-				<value>
-					<Bulk>1</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RHApparel_LugoCap"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== Boonie Hat A-TACS AU (Delta) ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RHApparel_ATACSAUBoonie_Delta"]/statBases</xpath>
-				<value>
-					<Bulk>1</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RHApparel_ATACSAUBoonie_Delta"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla fabric hats -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/CP Spec Ops The Line/CP_SOTL_CE_Patch_RangedIndustrial_SF_Pack.xml
+++ b/Patches/CP Spec Ops The Line/CP_SOTL_CE_Patch_RangedIndustrial_SF_Pack.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Delta"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== HK416 SD Wolfpack ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,8 +102,13 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416SD_Wolfpack"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_M4A1Delta" or
+					defName="RNGun_HK416SD_Wolfpack"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_Apparel_Armor_Headgear.xml
@@ -11,7 +11,10 @@
 			<!-- ========== FAST helmet Assault Merc ========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmet_CDAssault"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_FASTHelmet_CDAssault" or
+					defName="RNApparel_FASTHelmet_CDSupport"
+				]/statBases</xpath>
 				<value>
 					<Bulk>3.5</Bulk>
 					<WornBulk>1</WornBulk>
@@ -22,31 +25,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmet_CDAssault"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_FASTHelmet_CDAssault" or
+					defName="RNApparel_FASTHelmet_CDSupport"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>  
-
-			<!-- ========== FAST helmet Support Merc ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmet_CDSupport"]/statBases</xpath>
-				<value>
-					<Bulk>3.5</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
 				</value>
 			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmet_CDSupport"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li> 
 
 		</operations>
 	</Operation>

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_Apparel_Headgear.xml
@@ -21,7 +21,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_Balaclava_CDCQB"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla tuque -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
@@ -38,7 +39,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_Hood_MercSniper"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla fabric hats -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_Apparel_OnSkin.xml
@@ -14,7 +14,7 @@
 				<xpath>Defs/ThingDef[defName="RNApparel_combats_Softshell_CD"]/statBases</xpath>
 				<value>
 					<Bulk>8</Bulk>
-					<WornBulk>5</WornBulk>
+					<WornBulk>3</WornBulk>
 					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 					<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
 				</value>
@@ -23,8 +23,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_combats_Softshell_CD"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_LMG.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_LMG.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HAMRIARLMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== LSAT ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,8 +102,13 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_LSATLMG"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_HAMRIARLMG" or
+					defName="RNGun_LSATLMG"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_M_BoltAction.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_M_BoltAction.xml
@@ -52,45 +52,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DSR50Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN Ballista ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -135,8 +96,13 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FNBallista"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_DSR50Sn" or
+					defName="RNGun_FNBallista"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_R_Others.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_R_Others.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SIGSG550AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch XM8 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,8 +102,13 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_XM8_ContractorAR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_SIGSG550AR" or
+					defName="RNGun_XM8_ContractorAR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_SMG.xml
@@ -57,45 +57,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKS74UKeymod_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== KRISS Vector Contractor ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,45 +102,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_KrissVectorContractor_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP7A1 ========== -->
@@ -229,45 +151,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP7A1_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== PDW-57 (Futuristic P90) ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -315,8 +198,15 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PDW57_PDW"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AKS74UKeymod_PDW" or
+					defName="RNGun_KrissVectorContractor_PDW" or
+					defName="RNGun_MP7A1_PDW" or
+					defName="RNGun_PDW57_PDW"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_Shotguns.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_Shotguns.xml
@@ -53,45 +53,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington870MCSS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Saiga-12K ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -137,8 +98,13 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Saiga12KS"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_Remington870MCSS" or
+					defName="RNGun_Saiga12KS"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_Apparel_Headgear.xml
@@ -7,95 +7,59 @@
 			<li Class="CombatExtended.PatchOperationFindMod">
 				<modName>[RH] Faction: Elite Crew</modName>
 			</li>
-			
-			<!-- ========== Shemagh 1337 white ========== -->
-			
+
+			<!-- ========== Shemagh 1337 (white, black, olive, tan variants) ========== -->
+
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_White"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_Shemagh_EliteCrew_White" or
+					defName="RNApparel_Shemagh_EliteCrew_Black" or
+					defName="RNApparel_Shemagh_EliteCrew_Olive" or
+					defName="RNApparel_Shemagh_EliteCrew_Tan"
+				]/statBases</xpath>
 				<value>
 					<Bulk>1</Bulk>
 					<WornBulk>1</WornBulk>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_White"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_Shemagh_EliteCrew_White" or
+					defName="RNApparel_Shemagh_EliteCrew_Black" or
+					defName="RNApparel_Shemagh_EliteCrew_Olive" or
+					defName="RNApparel_Shemagh_EliteCrew_Tan"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 				</value>
 			</li>
-			
-			<!-- ========== Shemagh 1337 black ========== -->
-			
+
+			<!-- ========== Shemagh 1337 scarf (canary and tan variants) ========== -->
+
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Black"]/statBases</xpath>
-				<value>
-					<Bulk>1</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Black"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			
-			<!-- ========== Shemagh 1337 olive ========== -->
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Olive"]/statBases</xpath>
-				<value>
-					<Bulk>1</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Olive"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			
-			<!-- ========== Shemagh 1337 tan ========== -->
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Tan"]/statBases</xpath>
-				<value>
-					<Bulk>1</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Tan"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			
-			<!-- ========== Shemagh 1337 canary (scarf) ========== -->
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Dad_Canary"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_Shemagh_EliteCrew_Dad_Canary" or
+					defName="RNApparel_Shemagh_EliteCrew_Dad_Tan"
+				]/statBases</xpath>
 				<value>
 					<Bulk>0.5</Bulk>
 					<WornBulk>0.5</WornBulk>
 				</value>
 			</li>
-			
-			<!-- ========== Shemagh 1337 tan (scarf) ========== -->
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_Shemagh_EliteCrew_Dad_Tan"]/statBases</xpath>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_Shemagh_EliteCrew_Dad_Canary" or
+					defName="RNApparel_Shemagh_EliteCrew_Dad_Tan"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<Bulk>0.5</Bulk>
-					<WornBulk>0.5</WornBulk>
+					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 				</value>
 			</li>
-			
+
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_Apparel_OnSkin.xml
@@ -35,8 +35,8 @@
 					defName="RNApparel_EliteCrew_Sage"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_M_BoltAction.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_M_BoltAction.xml
@@ -52,45 +52,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AW50Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== L96A1 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -138,8 +99,13 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_L96A1Sn"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AW50Sn" or
+					defName="RNGun_L96A1Sn"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Pistols.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Pistols.xml
@@ -53,35 +53,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DesertEagle"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN Five-seven ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -123,35 +94,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FiveSeven"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== TEC-9 ========== -->
@@ -200,8 +142,14 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_TEC-9P"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_DesertEagle" or
+					defName="RNGun_FiveSeven" or
+					defName="RNGun_TEC-9P"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_Apparel_Armor_Headgear.xml
@@ -8,10 +8,13 @@
 				<modName>[RH] Faction: Last Man Contingent</modName>
 			</li>
 
-			<!-- ========== PASGT helmet LMM ========== -->
+			<!-- ========== PASGT helmet (LMM, LMM II variants) ========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_PASGTLMMHelmet"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_PASGTLMMHelmet" or
+					defName="RNApparel_PASGTLMMHelmet_II"
+				]/statBases</xpath>
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>1</WornBulk>
@@ -22,36 +25,22 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_PASGTLMMHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_PASGTLMMHelmet"
+					defName="RNApparel_PASGTLMMHelmet_II"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
-			<!-- ========== PASGT helmet LMM II ========== -->
+			<!-- ========== FAST helmet (LMCT, LMM variants) ========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_PASGTLMMHelmet_II"]/statBases</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>6</ArmorRating_Sharp>
-					<ArmorRating_Blunt>13</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_PASGTLMMHelmet_II"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== FAST helmet LMCT ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetLMCT"]/statBases</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_FASTHelmetLMCT" or
+					defName="RNApparel_FASTHelmetLMM"
+				]/statBases</xpath>
 				<value>
 					<Bulk>4.5</Bulk>
 					<WornBulk>1</WornBulk>
@@ -62,27 +51,10 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetLMCT"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- ========== FAST helmet LMM ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetLMM"]/statBases</xpath>
-				<value>
-					<Bulk>4.5</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>7</ArmorRating_Sharp>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
-					<ArmorRating_Heat>0.54</ArmorRating_Heat>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNApparel_FASTHelmetLMM"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNApparel_FASTHelmetLMCT" or
+					defName="RNApparel_FASTHelmetLMM"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
 				</value>

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_Apparel_Headgear.xml
@@ -21,7 +21,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_Balaclava_LMM"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla tuque -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_Apparel_OnSkin.xml
@@ -23,8 +23,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_combats_Softshell_LMCT"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_HRT_Pack.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_HRT_Pack.xml
@@ -51,35 +51,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Glock17_HRT"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M9A1 - Hostage Rescue Team variant ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -122,8 +93,13 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M9A1_HRT"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_Glock17_HRT" or
+					defName="RNGun_M9A1_HRT"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_LMG.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_LMG.xml
@@ -57,45 +57,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PKMLMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== RPD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -145,8 +106,13 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_RPD"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_PKMLMG" or
+					defName="RNGun_RPD"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_M_BoltAction.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_M_BoltAction.xml
@@ -55,45 +55,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CSLR4Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SV-98 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,8 +102,13 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SV98Sn"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_CSLR4Sn" or
+					defName="RNGun_SV98Sn"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_M_DMR.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_M_DMR.xml
@@ -55,45 +55,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DragunovDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Barrett M107 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -136,45 +97,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M107AMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== QBU-88 (Type 88) ========== -->
@@ -224,8 +146,14 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_QBU88DMR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_DragunovDMR" or
+					defName="RNGun_M107AMR" or
+					defName="RNGun_QBU88DMR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_R_AK_Style.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_R_AK_Style.xml
@@ -58,45 +58,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK103AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AKM ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -147,8 +108,13 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKMAR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AK103AR" or
+					defName="RNGun_AKMAR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_R_AR_Style.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_R_AR_Style.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CAR15Bare"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch HK416 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -139,45 +100,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416Bare"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 Covert ========== -->
@@ -227,45 +149,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Covert"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Patriot Ordinance Factory P416 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -313,8 +196,15 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_P416Bare"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_CAR15Bare" or
+					defName="RNGun_HK416Bare" or
+					defName="RNGun_M4A1Covert" or
+					defName="RNGun_P416Bare"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_SMG.xml
@@ -54,45 +54,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKMSU_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MPX ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,45 +102,6 @@
 					<li>CE_AI_AssaultWeapon</li>
 					<li>CE_SMG</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MPX_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Uzi ========== -->
@@ -231,8 +153,14 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Uzi_PDW"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AKMSU_PDW" or
+					defName="RNGun_MPX_PDW" or
+					defName="RNGun_Uzi_PDW"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_Shotguns.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_Shotguns.xml
@@ -53,45 +53,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_KSGS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Remington 870 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -135,45 +96,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington870S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== UTAS UTS-15 ========== -->
@@ -221,8 +143,14 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_UTS15S"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_KSGS" or
+					defName="RNGun_Remington870S" or
+					defName="RNGun_UTS15S"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_Apparel_OnSkin.xml
@@ -29,8 +29,8 @@
 					defName="RNApparel_combats_Miller"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_Apparel_Headgear.xml
@@ -9,7 +9,7 @@
 			</li>
 
 			<!-- ========== Boonie Hat DCU ========== -->
-			
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RNApparel_DCUBoonie"]/statBases</xpath>
 				<value>
@@ -21,12 +21,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_DCUBoonie"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla fabric hats -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
 			<!-- ========== Balaclava Ghost ========== -->
-			
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RNApparel_Balaclava_Ghost"]/statBases</xpath>
 				<value>
@@ -34,11 +35,12 @@
 					<WornBulk>1</WornBulk>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_Balaclava_Ghost"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<!-- Equivalent to vanilla tuque -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_Apparel_OnSkin.xml
@@ -23,8 +23,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_combats_ATACSLEX"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction Umbra Company/RH_Umbra_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Red Horse Faction Umbra Company/RH_Umbra_CE_Patch_Apparel_OnSkin.xml
@@ -23,8 +23,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RNApparel_combats_Black"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor.xml
@@ -121,10 +121,14 @@
 					</value>
 				</li>
 
-				<!-- ========== AR500 armor (PMC) ========== -->
+				<!-- ========== AR500 armor (standard, PMC, Warrior variants) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_AR500Vest" or
+						defName="RNApparel_AR500PMCVest" or
+						defName="RNApparel_AR500WarriorVest"
+					]/statBases</xpath>
 					<value>
 						<Bulk>7.5</Bulk>
 						<WornBulk>5</WornBulk>
@@ -132,104 +136,44 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_AR500Vest" or
+						defName="RNApparel_AR500PMCVest" or
+						defName="RNApparel_AR500WarriorVest"
+					]/equippedStatOffsets</xpath>
 					<value>
 						<CarryBulk>10</CarryBulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_AR500Vest" or
+						defName="RNApparel_AR500PMCVest" or
+						defName="RNApparel_AR500WarriorVest"
+					]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_AR500Vest" or
+						defName="RNApparel_AR500PMCVest" or
+						defName="RNApparel_AR500WarriorVest"
+					]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>28</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500PMCVest"]/statBases/ArmorRating_Heat</xpath>
-					<value>
-						<ArmorRating_Heat>0.36</ArmorRating_Heat>
-					</value>
-				</li>
-
-				<!-- ========== AR500 armor ========== -->
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases</xpath>
-					<value>
-						<Bulk>7.5</Bulk>
-						<WornBulk>5</WornBulk>
-					</value>
-				</li>
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/equippedStatOffsets</xpath>
-					<value>
-						<CarryBulk>10</CarryBulk>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>28</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500Vest"]/statBases/ArmorRating_Heat</xpath>
-					<value>
-						<ArmorRating_Heat>0.36</ArmorRating_Heat>
-					</value>
-				</li>
-
-				<!-- ========== AR500 armor (Warrior) ========== -->
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases</xpath>
-					<value>
-						<Bulk>7.5</Bulk>
-						<WornBulk>5</WornBulk>
-					</value>
-				</li>
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/equippedStatOffsets</xpath>
-					<value>
-						<CarryBulk>10</CarryBulk>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>28</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_AR500WarriorVest"]/statBases/ArmorRating_Heat</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_AR500Vest" or
+						defName="RNApparel_AR500PMCVest" or
+						defName="RNApparel_AR500WarriorVest"
+					]/statBases/ArmorRating_Heat</xpath>
 					<value>
 						<ArmorRating_Heat>0.36</ArmorRating_Heat>
 					</value>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear.xml
@@ -115,10 +115,13 @@
 					</value>
 				</li>
 
-				<!-- ========== K6-3 helmet ========== -->
+				<!-- ========== K6-3 helmet (closed, open variants) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_K63Helmet"]/statBases</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_K63Helmet" or
+						defName="RNApparel_K63HelmetOpen"
+					]/statBases</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -127,18 +130,24 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_K63Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_K63Helmet" or
+						defName="RNApparel_K63HelmetOpen"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
-				<!-- ========== K6-3 helmet open ========== -->
+				<!-- ========== Lynx-T helmet (closed, open variants) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_K63HelmetOpen"]/statBases</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_LynxTHelmet" or
+						defName="RNApparel_LynxTHelmetOpen"
+					]/statBases</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -147,49 +156,12 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_K63HelmetOpen"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
-					</value>
-				</li>
-
-				<!-- ========== Lynx-T helmet ========== -->
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmet"]/statBases</xpath>
-					<value>
-						<Bulk>5</Bulk>
-						<WornBulk>1</WornBulk>
-						<ArmorRating_Sharp>10</ArmorRating_Sharp>
-						<ArmorRating_Blunt>22</ArmorRating_Blunt>
-						<ArmorRating_Heat>0.54</ArmorRating_Heat>
-					</value>
-				</li>
-				
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
-					</value>
-				</li>
-
-				<!-- ========== Lynx-T helmet open ========== -->
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmetOpen"]/statBases</xpath>
-					<value>
-						<Bulk>5</Bulk>
-						<WornBulk>1</WornBulk>
-						<ArmorRating_Sharp>10</ArmorRating_Sharp>
-						<ArmorRating_Blunt>22</ArmorRating_Blunt>
-						<ArmorRating_Heat>0.54</ArmorRating_Heat>
-					</value>
-				</li>
-				
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_LynxTHelmetOpen"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_LynxTHelmet" or
+						defName="RNApparel_LynxTHelmetOpen"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>0.30</StuffEffectMultiplierArmor>
 					</value>
@@ -227,7 +199,7 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_MASKA1Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
@@ -235,10 +207,13 @@
 					</value>
 				</li>
 
-				<!-- ========== PASGT helmet DCU ========== -->
+				<!-- ========== PASGT helmet (DCU, M81 variants) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/statBases</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_PASGTDCUHelmet" or
+						defName="RNApparel_PASGTM81Helmet"
+					]/statBases</xpath>
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>1</WornBulk>
@@ -249,27 +224,10 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
-					</value>
-				</li>  
-
-				<!-- ========== PASGT helmet M81 ========== -->
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/statBases</xpath>
-					<value>
-						<Bulk>4</Bulk>
-						<WornBulk>1</WornBulk>
-						<ArmorRating_Sharp>6</ArmorRating_Sharp>
-						<ArmorRating_Blunt>13</ArmorRating_Blunt>
-						<ArmorRating_Heat>0.54</ArmorRating_Heat>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_PASGTDCUHelmet" or
+						defName="RNApparel_PASGTM81Helmet"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
 					</value>
@@ -287,7 +245,7 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_PTABravoHelmetBlack"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
@@ -307,7 +265,7 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_PTABravoHelmetOperator"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
@@ -315,10 +273,13 @@
 					</value>
 				</li>  
 
-				<!-- ========== MICH helmet DPM ========== -->
+				<!-- ========== MICH helmet (DPM, Tan variants) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_DPM"]/statBases</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_MICHHelmet_DPM" or
+						defName="RNApparel_MICHHelmet_Tan"
+					]/statBases</xpath>
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>1</WornBulk>
@@ -327,33 +288,16 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_DPM"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_MICHHelmet_DPM" or
+						defName="RNApparel_MICHHelmet_Tan"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-					</value>
-				</li>  
-
-				<!-- ========== MICH helmet Tan ========== -->
-
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_Tan"]/statBases</xpath>
-					<value>
-						<Bulk>4</Bulk>
-						<WornBulk>1</WornBulk>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
-						<ArmorRating_Blunt>16</ArmorRating_Blunt>
-						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNApparel_MICHHelmet_Tan"]/statBases/StuffEffectMultiplierArmor</xpath>
-					<value>
-						<StuffEffectMultiplierArmor>0.20</StuffEffectMultiplierArmor>
-					</value>
-				</li>  
 
 				<!-- ========== Crye Airframe helmet ========== -->
 
@@ -367,7 +311,7 @@
 						<ArmorRating_Heat>0.54</ArmorRating_Heat>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_CryeAirframeHelmet_Tan"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear_Crafting_Rimfeller.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Armor_Headgear_Crafting_Rimfeller.xml
@@ -12,21 +12,15 @@
 						<li>Rimefeller</li>
 					</mods>
 					
-					<!-- If Rimefeller is also installed, have the PASGT helmets require Synthamide  for crafting -->					
+					<!-- If Rimefeller is also installed, have the PASGT helmets require Synthamide for crafting -->					
 					<match Class="PatchOperationSequence">
 						<operations>
 						
 							<li Class="PatchOperationReplace">
-								<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/costList</xpath>
-								<value>
-									<costList>
-										<Synthamide>10</Synthamide>
-									</costList>
-								</value>
-							</li>
-							
-							<li Class="PatchOperationReplace">
-								<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/costList</xpath>
+								<xpath>Defs/ThingDef[
+									defName="RNApparel_PASGTDCUHelmet" or
+									defName="RNApparel_PASGTM81Helmet"
+								]/costList</xpath>
 								<value>
 									<costList>
 										<Synthamide>10</Synthamide>
@@ -41,16 +35,10 @@
 						<operations>
 						
 							<li Class="PatchOperationReplace">
-								<xpath>Defs/ThingDef[defName="RNApparel_PASGTDCUHelmet"]/costList</xpath>
-								<value>
-									<costList>
-										<DevilstrandCloth>10</DevilstrandCloth>
-									</costList>
-								</value>
-							</li>
-							
-							<li Class="PatchOperationReplace">
-								<xpath>Defs/ThingDef[defName="RNApparel_PASGTM81Helmet"]/costList</xpath>
+								<xpath>Defs/ThingDef[
+									defName="RNApparel_PASGTDCUHelmet" or
+									defName="RNApparel_PASGTM81Helmet"
+								]/costList</xpath>
 								<value>
 									<costList>
 										<DevilstrandCloth>10</DevilstrandCloth>

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Headgear.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Headgear.xml
@@ -26,7 +26,8 @@
 					defName="RNApparel_BeretSOG"					
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<!-- Equivalent to vanilla fabric hats -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -65,7 +66,8 @@
 					defName="RNApparel_NomadCap"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<!-- Equivalent to vanilla fabric hats -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -90,7 +92,8 @@
 					defName="RNApparel_MulticamBoonie"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<!-- Equivalent to vanilla fabric hats -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -102,7 +105,8 @@
 					defName="RNApparel_BandanaTan"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -129,7 +133,8 @@
 					defName="RNApparel_BalaclavaKeegan"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<!-- Equivalent to vanilla tuque -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -147,9 +152,9 @@
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[
-					defName="RNApparel_Beanie" or
-					defName="RNApparel_M81Tuque" or
-					defName="RNApparel_MulticamTuque"
+						defName="RNApparel_Beanie" or
+						defName="RNApparel_M81Tuque" or
+						defName="RNApparel_MulticamTuque"
 					]/statBases</xpath>
 					<value>
 						<Bulk>1</Bulk>
@@ -159,12 +164,24 @@
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[
-					defName="RNApparel_Beanie" or
-					defName="RNApparel_M81Tuque" or
-					defName="RNApparel_MulticamTuque"
+						defName="RNApparel_Beanie" or
+						defName="RNApparel_M81Tuque" or
+						defName="RNApparel_MulticamTuque"
 					]/apparel/layers/li[.="Overhead"]</xpath>
 					<value>
 						<li>MiddleHead</li>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_Beanie" or
+						defName="RNApparel_M81Tuque" or
+						defName="RNApparel_MulticamTuque"
+					]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<!-- Equivalent to vanilla tuque -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -175,6 +192,14 @@
 					<value>
 						<Bulk>1.5</Bulk>
 						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RNApparel_BeanieDivision"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<!-- Equivalent to vanilla tuque -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -322,7 +347,8 @@
 					defName="RNApparel_MilitaryCap_Multicam"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<!-- Equivalent to vanilla fabric hats -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_OnSkin.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_OnSkin.xml
@@ -28,7 +28,8 @@
 					defName="RNApparel_combats_FleeceBlack"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+						<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -47,7 +48,8 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_combats_GORKA4C"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+						<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -76,6 +78,7 @@
 					defName="RNApparel_combats_Multicam"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
@@ -95,7 +98,8 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_Combats_Tanya"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+						<!-- Slightly tougher than vanilla pants, T-shirt and button-down shirt -->
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -126,12 +130,13 @@
 					defName="RNApparel_Plaid_Tan"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<!-- ========== Tank Tops with Trousers ========== -->
-				
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[
 					defName="RNApparel__Tank_ExplorerA" or
@@ -155,12 +160,13 @@
 					defName="RNApparel_Tank_Tenlyashka"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<!-- ========== Button Shirts with Trousers ========== -->
-				
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[
 					defName="RNApparel_Shirt_PUBGGray" or
@@ -188,12 +194,13 @@
 					defName="RNApparel_Shirt_Wick"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<!-- ========== Light Shirts with Trousers ========== -->
-				
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[
 					defName="RNApparel_Shirt_LiteDDPM" or
@@ -219,10 +226,11 @@
 					defName="RNApparel_Shirt_ButSarge"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				
+
 				<!-- ========== Causals Division ========== -->
 
 				<li Class="PatchOperationAdd">
@@ -238,12 +246,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_Hoodie_Ryan"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<!-- ========== Ada Wong outfit (Resident Evil) ========== -->
-				
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RNApparel_Shirt_AdaREmake"]/statBases</xpath>
 					<value>
@@ -257,10 +266,11 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RNApparel_Shirt_AdaREmake"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
+						<!-- Equivalent to vanilla pants, T-shirt and button-down shirt -->
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -53,24 +53,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_AT4RL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Carl Gustaf Recoiless Rifle ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -119,24 +101,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_CarlGustafRL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== China Lake Grenade Launcher ========== -->
@@ -190,45 +154,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_ChinaLakeGL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch HK69A1 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -278,45 +203,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_HK69A1GL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FGM-148 Javelin ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -364,24 +250,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_JavelinRL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M72 LAW ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -425,24 +293,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_M72LAW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M202 FLASH ========== -->
@@ -492,24 +342,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_M202FLASH"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M320 Grenade Launcher Module ========== -->
@@ -564,45 +396,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_M320GL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MATADOR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -647,24 +440,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_MATADORRL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MBT LAW / NLAW ========== -->
@@ -712,24 +487,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_MBTLAWRL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Milkor MGL ========== -->
@@ -782,45 +539,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_MilkorMGL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== RPG-7V2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -871,24 +589,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_RPG7V2RL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== RPG-28 Klyukva ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -933,24 +633,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_RPG28RL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== RPG-32 Barkas ========== -->
@@ -1004,24 +686,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_RPG32RL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SMAW ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1071,24 +735,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_SMAWRL"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>2.44</cooldownTime>
-							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== XM25 CDTE ========== -->
@@ -1141,8 +787,16 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNEx_XM25GL"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNEx_ChinaLakeGL" or
+					defName="RNEx_HK69A1GL" or
+					defName="RNEx_M320GL" or
+					defName="RNEx_MilkorMGL" or
+					defName="RNEx_XM25GL"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -1175,6 +829,36 @@
 							<cooldownTime>1.55</cooldownTime>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNEx_AT4RL" or
+					defName="RNEx_CarlGustafRL" or
+					defName="RNEx_JavelinRL" or
+					defName="RNEx_M72LAW" or
+					defName="RNEx_M202FLASH" or
+					defName="RNEx_MATADORRL" or
+					defName="RNEx_MBTLAWRL" or
+					defName="RNEx_RPG7V2RL" or
+					defName="RNEx_RPG28RL" or
+					defName="RNEx_RPG32RL" or
+					defName="RNEx_SMAWRL"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>2.44</cooldownTime>
+							<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
@@ -136,19 +136,7 @@
 				</operations>
 			</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RNThrown_C4CSGO"]/comps</xpath>
-				<value>
-					<li Class="CombatExtended.CompProperties_ExplosiveCE">
-						<explosionDamage>328</explosionDamage>
-						<explosionDamageDef>Bomb</explosionDamageDef>
-						<explosionRadius>4</explosionRadius>
-						<fragments>
-							<Fragment_GrenadeFrag>345</Fragment_GrenadeFrag>
-						</fragments>
-					</li>
-				</value>
-			</li>
+			<!-- Unthrown C4 does not have CombatExtended.CompProperties_ExplosiveCE, as C4 does not explode if dropped, shot at or set on fire -->
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>RNThrown_C4CSGO</defName>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_HRT_Pack.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_HRT_Pack.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_G36CHRT"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Glock 17 - Hostage Rescue Team variant ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -135,35 +96,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Glock17_HRT"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch HK417 - Hostage Rescue Team variant ========== -->
@@ -209,45 +141,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK417HRTDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 - Hostage Rescue Team variant ========== -->
@@ -297,45 +190,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1HRT"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M9A1 - Hostage Rescue Team variant ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -376,35 +230,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M9A1_HRT"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M24A2 - Hostage Rescue Team variant ========== -->
@@ -450,45 +275,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M24A2HRTSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP5A2 SD - Hostage Rescue Team variant ========== -->
@@ -538,45 +324,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5A2SDHRT_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== Remington 870 - Hostage Rescue Team variant ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -618,45 +365,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington870HRT"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== UMP 45 - Hostage Rescue Team variant ========== -->
@@ -706,8 +414,50 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_UMP45HRT_PDW"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_Glock17_HRT" or
+					defName="RNGun_M9A1_HRT"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_G36CHRT" or
+					defName="RNGun_HK417HRTDMR" or
+					defName="RNGun_M4A1HRT" or
+					defName="RNGun_M24A2HRTSn" or
+					defName="RNGun_MP5A2SDHRT_PDW" or
+					defName="RNGun_Remington870HRT" or
+					defName="RNGun_UMP45HRT_PDW"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_LMG.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_LMG.xml
@@ -57,45 +57,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DP27LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN Minimi ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -141,45 +102,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FNMinimi"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== FN Minimi C9A1 ========== -->
@@ -229,45 +151,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C9A1Minimi"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN MAG ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -313,45 +196,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FNMAG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== HK MG4 ========== -->
@@ -401,45 +245,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HKMG4LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== HK MG5 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -487,45 +292,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HKMG5LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== IMI Negev ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -571,45 +337,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_NegevLMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M60 ========== -->
@@ -661,45 +388,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M60LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M240B ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -745,45 +433,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M240B"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M249 ========== -->
@@ -833,45 +482,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M249LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Mk 48 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -917,45 +527,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MK48LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== PKM ========== -->
@@ -1007,45 +578,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PKMLMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== RPD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1093,45 +625,6 @@
 				<weaponTags>
 					<li>CE_MachineGun</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_RPD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== RPK-74 ========== -->
@@ -1183,45 +676,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_RPK74LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Zastava M84 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1271,8 +725,26 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM84LMG"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_DP27LMG" or
+					defName="RNGun_FNMinimi" or
+					defName="RNGun_C9A1Minimi" or
+					defName="RNGun_FNMAG" or
+					defName="RNGun_HKMG4LMG" or
+					defName="RNGun_HKMG5LMG" or
+					defName="RNGun_NegevLMG" or
+					defName="RNGun_M60LMG" or
+					defName="RNGun_M240B" or
+					defName="RNGun_M249LMG" or
+					defName="RNGun_MK48LMG" or
+					defName="RNGun_PKMLMG" or
+					defName="RNGun_RPD" or
+					defName="RNGun_RPK74LMG" or
+					defName="RNGun_ZastavaM84LMG"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_M_BoltAction.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_M_BoltAction.xml
@@ -52,45 +52,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AW50Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== C14 Timberwolf ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -133,45 +94,6 @@
 
 				<!-- No additional CE weaponTags needed -->
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C14TimberwolfSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== C3A1 ========== -->
@@ -218,45 +140,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C3A1Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== CDX-33 Patriot Lite ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -298,45 +181,6 @@
 
 				<!-- No additional CE weaponTags needed -->
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CDX33PatriotLiteSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== CS-LR4 ========== -->
@@ -386,45 +230,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CSLR4Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Desert Tech HTI ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -467,45 +272,6 @@
 
 				<!-- No additional CE weaponTags needed -->
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DesertTechHTISn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Desert Tech SRS ========== -->
@@ -552,45 +318,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DesertTechSRS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN Ballista ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -633,45 +360,6 @@
 
 				<!-- No additional CE weaponTags needed -->
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FNBallista"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== GOL Magnum ========== -->
@@ -721,45 +409,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_GOLMagnumSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Haenel RS9 / G29 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -804,45 +453,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HaenelRS9Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== CheyTac Intervention ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -885,45 +495,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_InterventionSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Kar98k ========== -->
@@ -973,45 +544,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Kar98k"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== L115A3 SD / Accuracy International AWM ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1055,45 +587,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_L115A3Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== L96A1 ========== -->
@@ -1143,45 +636,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_L96A1Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Lee Enfield ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1227,45 +681,6 @@
 				</weaponTags>
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_LeeEnfield"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M24A2 SD ========== -->
@@ -1315,45 +730,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M24A2SDSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M24A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1401,45 +777,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_GOLMagnumSn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M40A5 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1483,45 +820,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M40A3Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Mosin Nagant ========== -->
@@ -1571,45 +869,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MosinNagant"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Remington 700 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1653,45 +912,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_R700Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Remington MSR ========== -->
@@ -1738,45 +958,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_RemingtonMSR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SNIPEX M75 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1819,45 +1000,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SNIPEXM75Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Steyr SSG 08 ========== -->
@@ -1904,45 +1046,6 @@
 				</weaponTags>
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SSG08Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== SV-98 ========== -->
@@ -1992,45 +1095,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SV98Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== McMillan TAC-50 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2074,45 +1138,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_TAC50Sn"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Zastava M07 ========== -->
@@ -2162,8 +1187,37 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM07Sn"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AW50Sn" or
+					defName="RNGun_C14TimberwolfSn" or
+					defName="RNGun_C3A1Sn" or
+					defName="RNGun_CDX33PatriotLiteSn" or
+					defName="RNGun_CSLR4Sn" or
+					defName="RNGun_DesertTechHTISn" or
+					defName="RNGun_DesertTechSRS" or
+					defName="RNGun_FNBallista" or
+					defName="RNGun_GOLMagnumSn" or
+					defName="RNGun_HaenelRS9Sn" or
+					defName="RNGun_InterventionSn" or
+					defName="RNGun_Kar98k" or
+					defName="RNGun_L115A3Sn" or
+					defName="RNGun_L96A1Sn" or
+					defName="RNGun_LeeEnfield" or
+					defName="RNGun_M24A2SDSn" or
+					defName="RNGun_M24A2Sn" or
+					defName="RNGun_M40A3Sn" or
+					defName="RNGun_MosinNagant" or
+					defName="RNGun_R700Sn" or
+					defName="RNGun_RemingtonMSR" or
+					defName="RNGun_SNIPEXM75Sn" or
+					defName="RNGun_SSG08Sn" or
+					defName="RNGun_SV98Sn" or
+					defName="RNGun_TAC50Sn" or
+					defName="RNGun_ZastavaM07Sn"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -2200,7 +1254,7 @@
 					</tools>
 				</value>
 			</li>
-
+			
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_M_DMR.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_M_DMR.xml
@@ -55,45 +55,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AR10DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Accuracy International AS50 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -136,45 +97,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AS50AMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Dragunov SVD ========== -->
@@ -224,45 +146,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DragunovDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch G28 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -306,45 +189,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_G28DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch G3SG/1 ========== -->
@@ -394,45 +238,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_G3SGDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch HK417 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -476,45 +281,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK417DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== L129A1 ========== -->
@@ -562,45 +328,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_L129A1DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Barrett M107 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -643,45 +370,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M107AMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M110 SASS ========== -->
@@ -729,45 +417,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M110SASSDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M110 SASS SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -811,45 +460,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M110SASSSDDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M14 DMR ========== -->
@@ -899,45 +509,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M14DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M14 EBR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -982,45 +553,6 @@
 				</weaponTags>
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M14EBR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M14 EBR MIL-SPEC ========== -->
@@ -1069,45 +601,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M14EBRMilSpec"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Springfield Armory M1A VLTOR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1151,45 +644,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M14VLTOR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M21 SWS ========== -->
@@ -1239,45 +693,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M21DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M39 EMR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1320,45 +735,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M39EMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M39 EMR MIL-SPEC ========== -->
@@ -1405,45 +781,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M39EMRMilSpec"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Barrett M82A1 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1488,45 +825,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M82A1AMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Zijiang M99 / Type 99 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1569,45 +867,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M99AMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MK11 Mod 0 ========== -->
@@ -1655,45 +914,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MK11DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Mk 14 EBR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1736,45 +956,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Mk14EBR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch PSG-1 ========== -->
@@ -1820,45 +1001,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PSG1DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== QBU-88 (Type 88) ========== -->
@@ -1908,45 +1050,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_QBU88DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Kel-Tec RFB DMR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1994,45 +1097,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_RFBDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN SCAR Mk20 SSR ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2077,45 +1141,6 @@
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SCARMk20DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
 
 			<!-- ========== SKS DMR ========== -->
 
@@ -2162,45 +1187,6 @@
 				</weaponTags>
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SKSDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== SKS DMR-SD ========== -->
@@ -2250,45 +1236,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SKSSDDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SR-25 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2334,45 +1281,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SR25DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Kalashnikov SVK ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2416,45 +1324,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SVKDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== OTs-03 SVU-A ========== -->
@@ -2506,45 +1375,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SVUADMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== OTs-03 SVU ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2588,45 +1418,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SVUDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== VSS Vintorez ========== -->
@@ -2679,45 +1470,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_VSSDMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Walther WA 2000 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2761,45 +1513,6 @@
 				<!-- No additional CE weaponTags needed -->
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_WA2000DMR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Zastava M76 ========== -->
@@ -2849,8 +1562,45 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM76DMR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AR10DMR" or
+					defName="RNGun_AS50AMR" or
+					defName="RNGun_DragunovDMR" or
+					defName="RNGun_G28DMR" or
+					defName="RNGun_G3SGDMR" or
+					defName="RNGun_HK417DMR" or
+					defName="RNGun_L129A1DMR" or
+					defName="RNGun_M107AMR" or
+					defName="RNGun_M110SASSDMR" or
+					defName="RNGun_M110SASSSDDMR" or
+					defName="RNGun_M14DMR" or
+					defName="RNGun_M14EBR" or
+					defName="RNGun_M14EBRMilSpec" or
+					defName="RNGun_M14VLTOR" or
+					defName="RNGun_M21DMR" or
+					defName="RNGun_M39EMR" or
+					defName="RNGun_M39EMRMilSpec" or
+					defName="RNGun_M82A1AMR" or
+					defName="RNGun_M99AMR" or
+					defName="RNGun_MK11DMR" or
+					defName="RNGun_Mk14EBR" or
+					defName="RNGun_PSG1DMR" or
+					defName="RNGun_QBU88DMR" or
+					defName="RNGun_RFBDMR" or
+					defName="RNGun_SCARMk20DMR" or
+					defName="RNGun_SKSDMR" or
+					defName="RNGun_SKSSDDMR" or
+					defName="RNGun_SR25DMR" or
+					defName="RNGun_SVKDMR" or
+					defName="RNGun_SVUADMR" or
+					defName="RNGun_SVUDMR" or
+					defName="RNGun_VSSDMR" or
+					defName="RNGun_WA2000DMR" or
+					defName="RNGun_ZastavaM76DMR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -2887,7 +1637,7 @@
 					</tools>
 				</value>
 			</li>
-
+			
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Pistols.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Pistols.xml
@@ -53,35 +53,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CZ75B"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Desert Eagle ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -127,35 +98,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DesertEagle"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Desert Eagle Gold ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -199,35 +141,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DesertEagleGold"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN Five-seven ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -269,35 +182,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FiveSeven"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Glock 17 ========== -->
@@ -346,35 +230,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Glock17P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Glock 34 Combat Master ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -416,35 +271,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Glock34CM"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== HS2000 / XD / XDM / XD-S ========== -->
@@ -493,35 +319,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HS2000P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M1911A1 Hellfighter ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -562,35 +359,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M1911_Hellfighter"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M1911A1 ========== -->
@@ -638,35 +406,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M1911A1P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M1911A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -709,35 +448,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M1911A2P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M45A1 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -778,35 +488,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M45A1_Pistol"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M9A1 ========== -->
@@ -854,35 +535,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M9A1P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Makarov (PM) ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -928,35 +580,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Makarov"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== USSOCOM MK23 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -998,35 +621,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MK23P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP445 ========== -->
@@ -1075,35 +669,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP445P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SIG Sauer P226 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1147,35 +712,6 @@
 					<li>CE_AI_Pistol</li>
 					<li>CE_Sidearm</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_P226P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== SIG Sauer P320 ========== -->
@@ -1224,35 +760,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_P320P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Taurus PT92 "Luison" ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1293,35 +800,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PT92Luison"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== TEC-9 ========== -->
@@ -1370,35 +848,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_TEC-9P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== TT-30 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1444,35 +893,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_TT30P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== USP45 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1514,35 +934,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_USP45SD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Walther PPK ========== -->
@@ -1590,8 +981,33 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_WaltherPPK"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_CZ75B" or
+					defName="RNGun_DesertEagle" or
+					defName="RNGun_DesertEagleGold" or
+					defName="RNGun_FiveSeven" or
+					defName="RNGun_Glock17P" or
+					defName="RNGun_Glock34CM" or
+					defName="RNGun_HS2000P" or
+					defName="RNGun_M1911_Hellfighter" or
+					defName="RNGun_M1911A1P" or
+					defName="RNGun_M1911A2P" or
+					defName="RNGun_M45A1_Pistol" or
+					defName="RNGun_M9A1P" or
+					defName="RNGun_Makarov" or
+					defName="RNGun_MK23P" or
+					defName="RNGun_MP445P" or
+					defName="RNGun_P226P" or
+					defName="RNGun_P320P" or
+					defName="RNGun_PT92Luison" or
+					defName="RNGun_TEC-9P" or
+					defName="RNGun_TT30P" or
+					defName="RNGun_USP45SD" or
+					defName="RNGun_WaltherPPK"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_AK_Style.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_AK_Style.xml
@@ -58,45 +58,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AEK971AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AK-103 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -147,45 +108,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK103AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AK-104 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -232,45 +154,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK104AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== AK-12 ========== -->
@@ -321,45 +204,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK12AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AK-15 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -406,45 +250,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK15AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== AK-47 ========== -->
@@ -497,45 +302,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK47AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AK-47 Gold ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -585,45 +351,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK47GoldAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== AK-47 Modern ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -672,45 +399,6 @@
 				<weaponTags>
 					<li>CE_AI_Rifle</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK47ModernAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== AK-74 ========== -->
@@ -763,45 +451,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK74AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AK-74 Tactical ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -850,45 +499,6 @@
 				<weaponTags>
 					<li>CE_AI_Rifle</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK74TacticalAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== AKM ========== -->
@@ -941,45 +551,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKMAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AKM Tactical ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1026,45 +597,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKMTacticalAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== AKS-47 ========== -->
@@ -1117,45 +649,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKS47AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AN-94 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1202,45 +695,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AN94AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Type 56 ========== -->
@@ -1293,45 +747,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Type56AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Zastava M21 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1378,45 +793,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM21AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Zastava M70AB2 ========== -->
@@ -1469,45 +845,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM70AB2AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Zastava M70 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1558,8 +895,29 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM70AR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AEK971AR" or
+					defName="RNGun_AK103AR" or
+					defName="RNGun_AK104AR" or
+					defName="RNGun_AK12AR" or
+					defName="RNGun_AK15AR" or
+					defName="RNGun_AK47AR" or
+					defName="RNGun_AK47GoldAR" or
+					defName="RNGun_AK47ModernAR" or
+					defName="RNGun_AK74AR" or
+					defName="RNGun_AK74TacticalAR" or
+					defName="RNGun_AKMAR" or
+					defName="RNGun_AKMTacticalAR" or
+					defName="RNGun_AKS47AR" or
+					defName="RNGun_AN94AR" or
+					defName="RNGun_Type56AR" or
+					defName="RNGun_ZastavaM21AR" or
+					defName="RNGun_ZastavaM70AB2AR" or
+					defName="RNGun_ZastavaM70AR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -1596,7 +954,7 @@
 					</tools>
 				</value>
 			</li>
-
+			
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_AR_Style.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_AR_Style.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_DDM4AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch HK416 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -139,45 +100,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416Bare"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch HK416 Elite ========== -->
@@ -227,45 +149,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416Elite"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch HK416 Nomad ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -313,45 +196,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416Nomad"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== Heckler & Koch HK416 SD Predator ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -397,45 +241,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416SD_Predator"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch HK416 SD DEVGRU ========== -->
@@ -485,45 +290,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416SD_DEVGRU"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch HK416 SD Punisher ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -571,45 +337,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HK416PunisherSD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== War Sport Industries LVOA-C ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -655,45 +382,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_LVOACAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M16A1 ========== -->
@@ -743,45 +431,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M16A1Bare"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M16A4 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -827,45 +476,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M16A4AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M16A4 MIL-SPEC ========== -->
@@ -915,45 +525,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M16A4MilSpec"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch M27 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -999,45 +570,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M27AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch M27 IAR ========== -->
@@ -1087,45 +619,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M27IAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch M27 IAR SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1171,45 +664,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M27IAR_SD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 Kandahar ========== -->
@@ -1259,45 +713,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1343,45 +758,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Bare"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 SD ========== -->
@@ -1431,45 +807,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1BareSD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 Benghazi ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1515,45 +852,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Benghazi"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 Blackout ========== -->
@@ -1603,45 +901,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Black"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 Fallujah ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1687,45 +946,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Fallujah"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 Ghost ========== -->
@@ -1775,45 +995,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Ghost"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 Hunter ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1859,45 +1040,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Hunter"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 MIL-SPEC ========== -->
@@ -1947,45 +1089,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1MilSpec"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 SD MIL-SPEC ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2031,45 +1134,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1MilSpecSD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 SD Ramadi ========== -->
@@ -2119,45 +1183,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1RamadiSD"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 Roach ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2203,45 +1228,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1RoachAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 SD Banshee ========== -->
@@ -2291,45 +1277,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1SD_Banshee"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 SD Commando ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2375,45 +1322,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1SD_Commando"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== M4A1 SD VLTOR ========== -->
@@ -2463,45 +1371,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1SD_VLTOR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M4A1 Warfighter ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2547,45 +1416,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M4A1Warfighter"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Patriot Ordinance Factory P416 ========== -->
@@ -2635,45 +1465,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_P416Bare"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SIG Sauer SIGM400 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2719,45 +1510,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SIGM400Tread"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Smith & Wesson MP15 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2799,45 +1551,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SWMP15AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Bushmaster XM-15 ========== -->
@@ -2885,8 +1598,45 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_XM15AR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_DDM4AR" or
+					defName="RNGun_HK416Bare" or
+					defName="RNGun_HK416Elite" or
+					defName="RNGun_HK416Nomad" or
+					defName="RNGun_HK416SD_Predator" or
+					defName="RNGun_HK416SD_DEVGRU" or
+					defName="RNGun_HK416PunisherSD" or
+					defName="RNGun_LVOACAR" or
+					defName="RNGun_M16A1Bare" or
+					defName="RNGun_M16A4AR" or
+					defName="RNGun_M16A4MilSpec" or
+					defName="RNGun_M27AR" or
+					defName="RNGun_M27IAR" or
+					defName="RNGun_M27IAR_SD" or
+					defName="RNGun_M4A1AR" or
+					defName="RNGun_M4A1Bare" or
+					defName="RNGun_M4A1BareSD" or
+					defName="RNGun_M4A1Benghazi" or
+					defName="RNGun_M4A1Black" or
+					defName="RNGun_M4A1Fallujah" or
+					defName="RNGun_M4A1Ghost" or
+					defName="RNGun_M4A1Hunter" or
+					defName="RNGun_M4A1MilSpec" or
+					defName="RNGun_M4A1MilSpecSD" or
+					defName="RNGun_M4A1RamadiSD" or
+					defName="RNGun_M4A1RoachAR" or
+					defName="RNGun_M4A1SD_Banshee" or
+					defName="RNGun_M4A1SD_Commando" or
+					defName="RNGun_M4A1SD_VLTOR" or
+					defName="RNGun_M4A1Warfighter" or
+					defName="RNGun_P416Bare" or
+					defName="RNGun_SIGM400Tread" or
+					defName="RNGun_SWMP15AR" or
+					defName="RNGun_XM15AR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -2923,7 +1673,7 @@
 					</tools>
 				</value>
 			</li>
-
+			
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Bullpup_Style.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Bullpup_Style.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AUGA2AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Steyr AUG A3 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -139,45 +100,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AUGA3SDAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== F2000 ========== -->
@@ -227,45 +149,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_F2000AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FAMAS ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -311,45 +194,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FAMASAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Groza-4 ========== -->
@@ -399,45 +243,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Groza4AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== L85A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -483,45 +288,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_L85A2MILSPEC"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Type 97 / QBZ-95 ========== -->
@@ -571,8 +337,18 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Type97AR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AUGA2AR" or
+					defName="RNGun_AUGA3SDAR" or
+					defName="RNGun_F2000AR" or
+					defName="RNGun_FAMASAR" or
+					defName="RNGun_Groza4AR" or
+					defName="RNGun_L85A2MILSPEC" or
+					defName="RNGun_Type97AR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Colt_Canada.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Colt_Canada.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C7A1AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Colt Canada C7A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -139,45 +100,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C7A2AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Colt Canada C8A2 ========== -->
@@ -227,45 +149,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C8A2AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Colt Canada C8A3 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -311,45 +194,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C8A3AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Colt Canada C8SFW ========== -->
@@ -399,45 +243,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C8SFWAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Colt Canada C8SFW SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -485,8 +290,17 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_C8SFWSDAR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_C7A1AR" or
+					defName="RNGun_C7A2AR" or
+					defName="RNGun_C8A2AR" or
+					defName="RNGun_C8A3AR" or
+					defName="RNGun_C8SFWAR" or
+					defName="RNGun_C8SFWSDAR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Others.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Others.xml
@@ -55,45 +55,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ACRAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== CZ 805 BREN A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -143,45 +104,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CZ805A2AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FB Beryl ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -227,45 +149,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FBBerylAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== FN FAL ========== -->
@@ -315,45 +198,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FNFALAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN FNC ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -399,45 +243,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_FNFNCAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Heckler & Koch G36C ========== -->
@@ -487,45 +292,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_G36CAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Heckler & Koch G36C SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -571,45 +337,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_G36CSDAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Daewoo K2C ========== -->
@@ -661,45 +388,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_K2CAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== WAT-FB MSBS-5.56 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -749,45 +437,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MSBS556AR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== FN SCAR-H ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -833,45 +482,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SCARHAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== FN SCAR-L ========== -->
@@ -921,45 +531,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SCARLAR"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== Heckler & Koch XM8 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1007,8 +578,23 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_XM8AR"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_ACRAR" or
+					defName="RNGun_CZ805A2AR" or
+					defName="RNGun_FBBerylAR" or
+					defName="RNGun_FNFALAR" or
+					defName="RNGun_FNFNCAR" or
+					defName="RNGun_G36CAR" or
+					defName="RNGun_G36CSDAR" or
+					defName="RNGun_K2CAR" or
+					defName="RNGun_MSBS556AR" or
+					defName="RNGun_SCARHAR" or
+					defName="RNGun_SCARLAR" or
+					defName="RNGun_XM8AR"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -1045,7 +631,7 @@
 					</tools>
 				</value>
 			</li>
-
+			
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Revolvers.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Revolvers.xml
@@ -55,35 +55,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ColtCobra"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Colt Peacemaker ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -129,35 +100,6 @@
 					<li>CE_AI_Pistol</li>
 					<li>CE_Sidearm</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ColtPeacemaker"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Colt Peacemaker II ========== -->
@@ -207,35 +149,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ColtPeacemaker_II"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Colt Python ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -281,35 +194,6 @@
 					<li>CE_AI_Pistol</li>
 					<li>CE_Sidearm</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ColtPython"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Mateba Model 6 Unica ========== -->
@@ -359,35 +243,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Mateba"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MP-412 REX ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -435,35 +290,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP412REX"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== Nagant M1895 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -509,35 +335,6 @@
 					<li>CE_AI_Pistol</li>
 					<li>CE_Sidearm</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_NagantRevolver"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Taurus Raging Bull ========== -->
@@ -587,35 +384,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_RagingBull"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Remington 1858 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -661,35 +429,6 @@
 					<li>CE_AI_Pistol</li>
 					<li>CE_Sidearm</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington1858P"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Smith & Wesson Model 29 ========== -->
@@ -739,8 +478,21 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SWModel29P"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_ColtCobra" or
+					defName="RNGun_ColtPeacemaker" or
+					defName="RNGun_ColtPeacemaker_II" or
+					defName="RNGun_ColtPython" or
+					defName="RNGun_Mateba" or
+					defName="RNGun_MP412REX" or
+					defName="RNGun_NagantRevolver" or
+					defName="RNGun_RagingBull" or
+					defName="RNGun_Remington1858P" or
+					defName="RNGun_SWModel29P"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
@@ -57,45 +57,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AK74U_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== AKMS-U ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -140,45 +101,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKMSU_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== AKS-74U ========== -->
@@ -228,45 +150,6 @@
 					<li>CE_AI_AssaultWeapon</li>
 					<li>CE_SMG</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AKS74U_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== CZ Scorpion EVO 3 ========== -->
@@ -319,45 +202,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_CZScorpion_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Honey Badger ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -405,45 +249,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_HoneyBadger_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== KRISS Vector ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -488,45 +293,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_KrissVector_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== KRISS Vector Contractor ========== -->
@@ -576,45 +342,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_KrissVectorContractor_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MAC-11 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -661,45 +388,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MAC11_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MAC-11 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -744,35 +432,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MAC11SD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP 40 ========== -->
@@ -825,45 +484,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP40_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MP5A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -914,45 +534,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5A2_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MP5SD2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -998,45 +579,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5A2SD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP5A3 ========== -->
@@ -1086,45 +628,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5A3_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MP5SD3 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1169,45 +672,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5A3SD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP5K-PDW ========== -->
@@ -1260,45 +724,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5KPDW_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MP5K-A3 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1349,45 +774,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP5KPDWSD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MP7A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1433,45 +819,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP7_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== MP9 ========== -->
@@ -1524,45 +871,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MP9_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== MPX ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1613,45 +921,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_MPX_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== P90 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1699,45 +968,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_P90_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== P90 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1783,45 +1013,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_P90SD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== PP-19 Bizon ========== -->
@@ -1873,45 +1064,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PP19_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== PP-2000 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1957,45 +1109,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PP2000_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== PPSh-41 ========== -->
@@ -2048,45 +1161,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_PPSh41_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Skorpion vz. 61 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2136,35 +1210,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SkorpionVZ61_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Skorpion vz. 61 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2212,35 +1257,6 @@
 					<li>CE_AI_AssaultWeapon</li>
 					<li>CE_SMG</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SkorpionVZ61SD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Thompson SMG ========== -->
@@ -2293,45 +1309,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ThompsonSMG_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== UMP45 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2382,45 +1359,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_UMP45_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
-
 			<!-- ========== UMP45 SD ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2467,45 +1405,6 @@
 
 				<!-- No additional CE weaponTags needed -->
 			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_UMP45SD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
 
 			<!-- ========== Uzi ========== -->
 
@@ -2554,45 +1453,6 @@
 					<li>CE_AI_AssaultWeapon</li>
 					<li>CE_SMG</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Uzi_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Uzi SD ========== -->
@@ -2644,45 +1504,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_UziSD_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Walther MPL ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -2730,45 +1551,6 @@
 					<li>CE_AI_AssaultWeapon</li>
 					<li>CE_SMG</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_WaltherMPL_PDW"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Zastava M92 ========== -->
@@ -2820,8 +1602,44 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_ZastavaM92_PDW"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AK74U_PDW" or
+					defName="RNGun_AKMSU_PDW" or
+					defName="RNGun_AKS74U_PDW" or
+					defName="RNGun_CZScorpion_PDW" or
+					defName="RNGun_HoneyBadger_PDW" or
+					defName="RNGun_KrissVector_PDW" or
+					defName="RNGun_KrissVectorContractor_PDW" or
+					defName="RNGun_MAC11_PDW" or
+					defName="RNGun_MAC11SD_PDW" or
+					defName="RNGun_MP40_PDW" or
+					defName="RNGun_MP5A2_PDW" or
+					defName="RNGun_MP5A2SD_PDW" or
+					defName="RNGun_MP5A3_PDW" or
+					defName="RNGun_MP5A3SD_PDW" or
+					defName="RNGun_MP5KPDW_PDW" or
+					defName="RNGun_MP5KPDWSD_PDW" or
+					defName="RNGun_MP7_PDW" or
+					defName="RNGun_MP9_PDW" or
+					defName="RNGun_MPX_PDW" or
+					defName="RNGun_P90_PDW" or
+					defName="RNGun_P90SD_PDW" or
+					defName="RNGun_PP19_PDW" or
+					defName="RNGun_PP2000_PDW" or
+					defName="RNGun_PPSh41_PDW" or
+					defName="RNGun_SkorpionVZ61_PDW" or
+					defName="RNGun_SkorpionVZ61SD_PDW" or
+					defName="RNGun_ThompsonSMG_PDW" or
+					defName="RNGun_UMP45_PDW" or
+					defName="RNGun_UMP45SD_PDW" or
+					defName="RNGun_Uzi_PDW" or
+					defName="RNGun_UziSD_PDW" or
+					defName="RNGun_WaltherMPL_PDW" or
+					defName="RNGun_ZastavaM92_PDW"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Shotguns.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Shotguns.xml
@@ -57,45 +57,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_AA12S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== KS-23 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -138,45 +99,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_KS23S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Kel-Tec KSG ========== -->
@@ -224,45 +146,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_KSGS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== M1014 / Benelli M4 Super 90 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -306,45 +189,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_M1014S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Model 1887 ========== -->
@@ -392,45 +236,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Model1887LA"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Model 1897 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -474,45 +279,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Model1897S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Mossberg 500 ========== -->
@@ -560,45 +326,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Mossberg500S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Mossberg 500 Tactical ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -642,45 +369,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Mossberg500TacticalS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Remington 870 Magnum ========== -->
@@ -728,45 +416,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington870MagnumS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Remington 870 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -810,45 +459,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington870S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Remington 870 Tactical ========== -->
@@ -896,45 +506,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Remington870TacticalS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Saiga-12 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -978,45 +549,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Saiga12S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Sawed-Off Shotgun ========== -->
@@ -1064,45 +596,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SawedOff"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== SPAS-12 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1147,45 +640,6 @@
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
 			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SPAS12S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>	
 
 			<!-- ========== Supernova ========== -->
 
@@ -1232,45 +686,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_Supernova"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Super-Shorty / Mossberg Maverick 88 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1314,45 +729,6 @@
 				<weaponTags>
 					<li>CE_AI_AssaultWeapon</li>
 				</weaponTags>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_SuperShorty"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== USAS-12 ========== -->
@@ -1404,45 +780,6 @@
 				</weaponTags>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_USAS12S"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== UTAS UTS-15 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1488,8 +825,25 @@
 				</weaponTags>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
+			<!-- shotguns with stocks -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNGun_UTS15S"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNGun_AA12S" or
+					defName="RNGun_KS23S" or
+					defName="RNGun_KSGS" or
+					defName="RNGun_M1014S" or
+					defName="RNGun_Mossberg500S" or
+					defName="RNGun_Mossberg500TacticalS" or
+					defName="RNGun_Remington870MagnumS" or
+					defName="RNGun_Remington870TacticalS" or
+					defName="RNGun_Saiga12S" or
+					defName="RNGun_SPAS12S" or
+					defName="RNGun_Supernova" or
+					defName="RNGun_USAS12S" or
+					defName="RNGun_UTS15S"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -1502,6 +856,52 @@
 							<chanceFactor>1.5</chanceFactor>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- shotguns without stocks -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="RNGun_Model1887LA" or
+					defName="RNGun_Model1897S" or
+					defName="RNGun_Remington870S" or
+					defName="RNGun_SawedOff" or
+					defName="RNGun_SuperShorty"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>barrel</label>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Spacer.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Spacer.xml
@@ -49,45 +49,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_AugerMkII"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Auger WS ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -127,45 +88,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_AugerWS"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== BM001 Razor ========== -->
@@ -209,45 +131,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_BM001Razor"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== BM003 Razor ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -287,45 +170,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_BM003Razor"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Bullseye Mk I ========== -->
@@ -369,45 +213,6 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_BullseyeMkI"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Bullseye Mk II ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -447,45 +252,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_BullseyeMkII"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Longbow 1S-1K ========== -->
@@ -528,45 +294,6 @@
 				</FireModes>
 
 				<!-- No additional CE weaponTags needed -->
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_Longbow1S1K"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<chanceFactor>1.5</chanceFactor>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>2.02</cooldownTime>
-							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Railgun ========== -->
@@ -613,8 +340,19 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RNSci_Railgun"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="RNSci_AugerMkII" or
+					defName="RNSci_AugerWS" or
+					defName="RNSci_BM001Razor" or
+					defName="RNSci_BM003Razor" or
+					defName="RNSci_BullseyeMkI" or
+					defName="RNSci_BullseyeMkII" or
+					defName="RNSci_Longbow1S1K" or
+					defName="RNSci_Railgun"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_Clothing.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_Clothing.xml
@@ -5,7 +5,7 @@
 		<operations>
 
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>WWII Soviet Faction (1.0)</modName>
+				<modName>WWII Soviet Faction</modName>
 			</li>
 
 			<!-- ========== M73 Uniform ========== -->

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_Headgear.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_Headgear.xml
@@ -5,7 +5,7 @@
 		<operations>
 
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>WWII Soviet Faction (1.0)</modName>
+				<modName>WWII Soviet Faction</modName>
 			</li>
 
 			<!-- ========== M73Cap =========== -->	

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_PawnKindDefs.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_PawnKindDefs.xml
@@ -5,7 +5,7 @@
 		<operations>
 
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>WWII Soviet Faction (1.0)</modName>
+				<modName>WWII Soviet Faction</modName>
 			</li>
 
 			<!-- ========== Reduce meals and medicine carried by all pawns ========== -->

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
@@ -5,7 +5,7 @@
 		<operations>
 
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>WWII Soviet Faction (1.0)</modName>
+				<modName>WWII Soviet Faction</modName>
 			</li>
 
 			<!-- ========== Mosin ========== -->
@@ -51,44 +51,6 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_WWII_MosinNagant_Normal"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>3.02</cooldownTime>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Mosin Bayonet ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -99,7 +61,8 @@
 					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.03</ShotSpread>
 					<SwayFactor>2.07</SwayFactor>
-					<Bulk>12.32</Bulk> <!-- Bulk reduced to non-bayonet version, assuming bayonet has negligible effect on overall bulk -->
+					<Bulk>12.32</Bulk>
+					<!-- Bulk reduced to non-bayonet version, assuming bayonet has negligible effect on overall bulk -->
 					<WorkToMake>14000</WorkToMake>
 				</statBases>
 				<costList>
@@ -130,46 +93,6 @@
 				</FireModes>
 
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_WWII_MosinNagant_Bayonet"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>bayonet</label>
-							<capacities>
-								<li>Cut</li>
-							</capacities>
-							<power>11</power>
-							<cooldownTime>1.23</cooldownTime>
-							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.48</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.63</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>bayonet</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>15</power>
-							<cooldownTime>3.02</cooldownTime>
-							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-							<armorPenetrationSharp>2.67</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== PPsh-41 ========== -->
@@ -217,44 +140,6 @@
 				</FireModes>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_WWII_PPShSMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>3.02</cooldownTime>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== DP-28 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -300,44 +185,6 @@
 				</FireModes>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_DP-28_LMG"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>barrel</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>3.02</cooldownTime>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-
 			<!-- ========== Nagant Revolver ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -377,34 +224,6 @@
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>Snapshot</aiAimMode>
 				</FireModes>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_Nagant_Revolver"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>grip</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.56</cooldownTime>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>muzzle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.54</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
 			</li>
 
 			<!-- ========== Svt-40 ========== -->
@@ -450,8 +269,16 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- == Shared patches for firearm melee tools == -->
+
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_WWII_Svt-40_Rifle"]/tools</xpath>
+				<xpath>Defs/ThingDef[
+					defName="Gun_WWII_MosinNagant_Normal" or
+					defName="Gun_WWII_MosinNagant_Bayonet" or
+					defName="Gun_WWII_PPShSMG" or
+					defName="Gun_DP-28_LMG" or
+					defName="Gun_WWII_Svt-40_Rifle"
+				]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -460,9 +287,10 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>8</power>
-							<cooldownTime>1.79</cooldownTime>
-							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>barrel</label>
@@ -470,9 +298,9 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>5</power>
-							<cooldownTime>3.02</cooldownTime>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1.63</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>muzzle</label>
@@ -481,8 +309,37 @@
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.55</cooldownTime>
-							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Gun_Nagant_Revolver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_Turret.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_Turret.xml
@@ -5,7 +5,7 @@
 		<operations>
 
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>WWII Soviet Faction (1.0)</modName>
+				<modName>WWII Soviet Faction</modName>
 			</li>
 
 			<!-- ========== ZiS (76 mm divisional gun M1942) ========== -->
@@ -31,6 +31,7 @@
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
+					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
@@ -45,7 +46,7 @@
 					<li>TurretGun</li>
 				</weaponTags>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Gun_TurretZis"]/soundInteract</xpath>
 				<value>
@@ -82,14 +83,14 @@
 					<MaxHitPoints>400</MaxHitPoints>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Turret_Zis"]/statBases/WorkToBuild</xpath>
 				<value>
 					<WorkToBuild>94500</WorkToBuild>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Turret_Zis"]/statBases/Mass</xpath>
 				<value>


### PR DESCRIPTION
General rebalancing, optimization and consistency pass for earlier Chicken Plucker mod patches

* Apparel stats and ranged weapon melee tool PatchOps consolidated where possible
* Rebalanced some apparel `StuffEffectMultiplierArmor` for consistency across all CP mods
  * Most hats, balaclavas, scarfs etc. are in line with vanilla CE items
  * Combat fatigues are slightly tougher than vanilla CE T-shirts and pants
* Removed `CompProperties_ExplosiveCE` from RN Weapons version of the throwable C4 item, as C4 is an insensitive explosive
  * This brings it in line with the existing implementation in RH Faction: Elite Crew
* Update WWII Soviet Faction
  * Patches now look for the new (non-version specific) mod name
  * Add missing Mounted `recoilPattern` for ZiS Divisional Gun turret