### PR TITLE
Convert EMP Grenadier into "Advanced Grenadier"

### DIFF
--- a/Patches/Core/FactionDefs/Factions_Misc.xml
+++ b/Patches/Core/FactionDefs/Factions_Misc.xml
@@ -47,14 +47,14 @@
   <Operation Class="PatchOperationRemove">
   	<xpath>Defs/FactionDef[defName="OutlanderCivil" or defName="Pirate"]/pawnGroupMakers/li/*/GrenadierDestructive</xpath>
   </Operation>
--->
 
-  <Operation Class="PatchOperationRemove">
-  	<xpath>Defs/FactionDef[defName="OutlanderFactionBase" or defName="Pirate"]/pawnGroupMakers/li/*/Grenadier_EMP</xpath>
-  </Operation>
 
   <Operation Class="PatchOperationRemove">
   	<xpath>Defs/FactionDef[defName="OutlanderFactionBase" or defName="Pirate"]/pawnGroupMakers/li/*/Grenadier_Smoke</xpath>
+  </Operation>
+-->
+  <Operation Class="PatchOperationRemove">
+  	<xpath>Defs/FactionDef[defName="OutlanderFactionBase" or defName="Pirate"]/pawnGroupMakers/li/*/Grenadier_EMP</xpath>
   </Operation>
 
   <!-- ========== Add tribal grenadies ========== -->

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -96,21 +96,41 @@
         </primaryMagazineCount>
         <forcedSidearm>
           <sidearmMoney>
-            <min>150</min>
-            <max>350</max>
+            <min>250</min>
+            <max>100</max>
           </sidearmMoney>
           <weaponTags>
-            <li>CE_Sidearm_Melee</li>
+            <li>CE_Sidearm</li>
           </weaponTags>
+        <magazineCount>
+          <min>2</min>
+          <max>5</max>
+        </magazineCount>          
         </forcedSidearm>
       </li>
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="Grenadier_EMP"]/label</xpath>
+    <value>
+	    <label>advanced grenadier</label>
+    </value>
+  </Operation>
+
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/PawnKindDef[defName="Grenadier_Smoke"]/weaponTags</xpath>
+    <xpath>Defs/PawnKindDef[defName="Grenadier_EMP"]/weaponTags</xpath>
     <value>
       <li>CE_GrenadeFlashbang</li>
+	    <li>GrenadeSmoke</li>
+	    <li>GrenadeDestructive</li>	
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/PawnKindDef[defName="Grenadier_EMP"]</xpath>
+    <value>
+      <combatPower>85</combatPower>
     </value>
   </Operation>
 


### PR DESCRIPTION
With the specific "smoke" and "EMP" grenadiers being of questionable effectiveness in a raid, this rebalances EMP grenadiers (smoke grenadiers are patched out) by converting them into an "advanced grenadier" pawnKind, with more weaponMoney and access to better weapons and sidearms.

Should generally be balanced with adjustment of their combatpower, but since I've allowed them to spawn w/ flashbangs, smoke grenades, and 40mm smoke rounds, there's the potential they might be weaker than intended--something to check in playtesting. 