### PR TITLE
labels must be in lower case unless proper nouns

### DIFF
--- a/Royalty/Defs/ThingDefs_Buildings/Buildings_Mech_Spawners.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Buildings_Mech_Spawners.xml
@@ -3,7 +3,7 @@
 
   <ThingDef ParentName="MechBuildingBase">
     <defName>CombatExtended_MechAmmoBeacon</defName>
-    <label>Mech Ammo Beacon</label>
+    <label>mech ammo beacon</label>
     <description>A mechanoid ammunition drop beacon. When activated, it calls in ammunition to land in drop pods nearby.</description>
     <size>(1,1)</size>
     <tickerType>Normal</tickerType>


### PR DESCRIPTION
Simple hotfix of newly-added mech ammo beacon building label.