### PR TITLE
1.1 - Ammo tweaks, mech Pikeman weapon fix.

### DIFF
--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -25,8 +25,8 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="40x46mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
     <description>Low velocity grenade fired from handheld grenade launchers.</description>
     <statBases>
-      <Mass>0.23</Mass>
-      <Bulk>0.38</Bulk>
+      <Mass>0.239</Mass>
+      <Bulk>0.40</Bulk>
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.33</MarketValue>
+      <MarketValue>2.37</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <comps>
@@ -72,7 +72,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>4.21</MarketValue>
+      <MarketValue>4.25</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
     <comps>
@@ -95,7 +95,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.92</MarketValue>
+      <MarketValue>1.96</MarketValue>
     </statBases>
     <ammoClass>Smoke</ammoClass>
     <comps>
@@ -177,7 +177,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>48</count>
+        <count>50</count>
       </li>
       <li>
         <filter>
@@ -206,7 +206,7 @@
     <products>
       <Ammo_40x46mmGrenade_HE>100</Ammo_40x46mmGrenade_HE>
     </products>
-    <workAmount>8800</workAmount>
+    <workAmount>9000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -221,7 +221,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>48</count>
+        <count>50</count>
       </li>
       <li>
         <filter>
@@ -241,7 +241,7 @@
     <products>
       <Ammo_40x46mmGrenade_EMP>100</Ammo_40x46mmGrenade_EMP>
     </products>
-    <workAmount>10800</workAmount>
+    <workAmount>11000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -256,7 +256,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>48</count>
+        <count>50</count>
       </li>
       <li>
         <filter>
@@ -285,7 +285,7 @@
     <products>
       <Ammo_40x46mmGrenade_Smoke>100</Ammo_40x46mmGrenade_Smoke>
     </products>
-    <workAmount>8000</workAmount>
+    <workAmount>8200</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -163,7 +163,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="GrenadeRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_100x695mmRCannonShell_HEAT</defName>
 		<label>make 100x695mmR HEAT cannon shells x5</label>
 		<description>Craft 5 100x695mmR HEAT cannon shells.</description>
@@ -207,7 +207,7 @@
 		</products>
 	</RecipeDef>
 
-	<RecipeDef ParentName="GrenadeRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_100x695mmRCannonShell_HE</defName>
 		<label>make 100x695mmR HE cannon shells x5</label>
 		<description>Craft 5 100x695mmR HE cannon shells.</description>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -160,7 +160,7 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="GrenadeRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_120mmCannonShell_HEAT</defName>
 		<label>make 120mm HEAT cannon shells x5</label>
 		<description>Craft 5 120mm HEAT cannon shells.</description>
@@ -204,7 +204,7 @@
 		</products>
 	</RecipeDef>
 
-	<RecipeDef ParentName="GrenadeRecipeBase">
+	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_120mmCannonShell_HE</defName>
 		<label>make 120mm HE cannon shells x5</label>
 		<description>Craft 5 120mm HE cannon shells.</description>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -49,7 +49,6 @@
     </tradeTags>
   </ThingDef>
 
-  <!-- Need to override mortar shell because of hardcoded vanilla references -->
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
     <defName>Shell_60mm_HE</defName>
     <label>60mm mortar shell (HE)</label>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -178,7 +178,7 @@
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.2,1.4</DrawSize>
-        <DrawOffset>0.0,-0.05</DrawOffset>
+        <DrawOffset>0.0,0.0</DrawOffset>
       </li>
     </modExtensions>
   </ThingDef>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -116,13 +116,14 @@
       <Bulk>7.31</Bulk>
       <Mass>20.00</Mass>
       <RangedWeapon_Cooldown>6</RangedWeapon_Cooldown>
+      <MarketValue>1400</MarketValue>      
     </statBases>
     <techLevel>Spacer</techLevel>
     <menuHidden>True</menuHidden>
     <tradeability>None</tradeability>
     <destroyOnDrop>true</destroyOnDrop>    
     <weaponTags>
-      <li>MechanoidGunLongRange</li>	  
+      <li>MechanoidGunLongRange</li>  
     </weaponTags>
     <verbs>
 	  <li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -26,6 +26,7 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
+					<label>fangs</label>
 					<capacities>
 						<li>ToxicBite</li>
 					</capacities>


### PR DESCRIPTION
## Additions

- Added market value to Explosive Bolt Projector, fixing issue of it not spawning.

## Changes

- Changed 100mR and 120mm ammo reciple bases, resolving #975 
- Adjusted 40x46mm grenade stats based on CE Projectile sheet, following some research.
- Removed Explosive Bolt Projector graphic offset.

## References

Links to the associated issues, e.g.
- Should close #975 

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] Confirmed Pikeman spawning with weapons and ammo as intended.
