### PR TITLE
Fix incorrect PatchOps causing RH Elite Crew pawns to have no ammo

### DIFF
--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_PawnKinds_EliteCrew.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_PawnKinds_EliteCrew.xml
@@ -59,7 +59,7 @@
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/PawnKindDef[
 					defName="RH_EliteCrew_CQB"
-					]/weaponTags/li[.="RN_FiveSeven"]</xpath>
+				]/weaponTags/li[.="RN_FiveSeven"]</xpath>
 			</li>
 			
 			<li Class="PatchOperationRemove">
@@ -67,14 +67,14 @@
 					defName="RH_EliteCrew_Scout" or
 					defName="RH_EliteCrew_CQB" or
 					defName="RH_EliteCrew_CQB_TierII"
-					]/weaponTags/li[.="RN_DesertEagle"]</xpath>
+				]/weaponTags/li[.="RN_DesertEagle"]</xpath>
 			</li>
 			
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/PawnKindDef[
 					defName="RH_EliteCrew_Grunt" or
 					defName="RH_EliteCrew_CQB"
-					]/weaponTags/li[.="RN_TerroristKnife"]</xpath>
+				]/weaponTags/li[.="RN_SkinnerKnife"]</xpath>
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
@@ -89,7 +89,7 @@
 							<li>
 								<generateChance>1</generateChance>
 								<weaponTags>
-									<li>RN_TerroristKnife</li>
+									<li>RN_SkinnerKnife</li>
 								</weaponTags>
 							</li>
 						</sidearms>
@@ -133,7 +133,7 @@
 							<li>
 								<generateChance>1</generateChance>
 								<weaponTags>
-									<li>RN_TerroristKnife</li>
+									<li>RN_SkinnerKnife</li>
 								</weaponTags>
 							</li>
 						</sidearms>
@@ -165,7 +165,7 @@
 							<li>
 								<generateChance>1</generateChance>
 								<weaponTags>
-									<li>RN_TerroristKnife</li>
+									<li>RN_SkinnerKnife</li>
 								</weaponTags>
 							</li>
 						</sidearms>
@@ -197,7 +197,7 @@
 							<li>
 								<generateChance>1</generateChance>
 								<weaponTags>
-									<li>RN_TerroristKnife</li>
+									<li>RN_SkinnerKnife</li>
 								</weaponTags>
 							</li>
 						</sidearms>
@@ -229,7 +229,7 @@
 							<li>
 								<generateChance>1</generateChance>
 								<weaponTags>
-									<li>RN_TerroristKnife</li>
+									<li>RN_SkinnerKnife</li>
 								</weaponTags>
 							</li>
 						</sidearms>


### PR DESCRIPTION
## Changes

* Fix a number of incorrect PatchOps and defName references, which would otherwise indirectly cause RH: Elite Crew faction pawns to spawn without ammo for their weapons

## References

- Closes #1155 

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (10 minutes)
  * Verified that all Elite Crew pawns now correctly spawn with primary & secondary weapons, ammo and knives in their inventory
