### PR TITLE
Tweak Royalty Ultra tech weapon.

### DIFF
--- a/Royalty/Patches/ThingDefs_Misc/Weapons_BladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_BladelinkMelee.xml
@@ -93,22 +93,22 @@
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<label>Head</label>
+					<label>head</label>
 					<capacities>
-						<li>Blunt</li>
+					<li>Blunt</li>
 					</capacities>
-					<power>58</power>
+					<power>45</power>
 					<extraMeleeDamages>
 					<li>
 						<def>EMP</def>
-						<amount>11</amount>
+						<amount>8</amount>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>1.81</cooldownTime>
-					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>24</armorPenetrationBlunt>
+					<cooldownTime>2.5</cooldownTime>
+					<armorPenetrationBlunt>157.5</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-				</li>
+					<chanceFactor>0.30</chanceFactor>
+				</li>	
 			</tools>
 		</value>
 	</Operation>
@@ -159,7 +159,7 @@
 					<capacities>
 						<li>Poke</li>
 					</capacities>
-					<power>5</power>
+					<power>3</power>
 					<cooldownTime>1.69</cooldownTime>
 					<chanceFactor>0.10</chanceFactor>
 					<armorPenetrationBlunt>0.80</armorPenetrationBlunt>
@@ -170,18 +170,18 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>64</power>
+					<power>45</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
-						<amount>10</amount>
+						<amount>8</amount>
 						<chance>0.3</chance>
 					</li>
 					</extraMeleeDamages>					
 					<cooldownTime>0.91</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>7.84</armorPenetrationBlunt>
-					<armorPenetrationSharp>15.68</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.20</armorPenetrationBlunt>
+					<armorPenetrationSharp>16</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -189,18 +189,18 @@
 					<capacities>
 					<li>Stab</li>
 					</capacities>
-					<power>32</power>
+					<power>20</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
-						<amount>10</amount>
-						<chance>0.3</chance>
+						<amount>5</amount>
+						<chance>0.2</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>2</cooldownTime>
-					<armorPenetrationBlunt>4.84</armorPenetrationBlunt>
-					<armorPenetrationSharp>24.20</armorPenetrationSharp>
-				</li>				
+					<cooldownTime>0.99</cooldownTime>
+					<armorPenetrationBlunt>3.24</armorPenetrationBlunt>
+					<armorPenetrationSharp>32.4</armorPenetrationSharp>
+				</li>					
 			</tools>
 		</value>
 	</Operation>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_BladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_BladelinkMelee.xml
@@ -22,11 +22,11 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>40</power>
-					<cooldownTime>0.79</cooldownTime>
+					<power>34</power>
+					<cooldownTime>0.92</cooldownTime>
 					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>3.125</armorPenetrationBlunt>
-					<armorPenetrationSharp>12.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.42</armorPenetrationBlunt>
+					<armorPenetrationSharp>9.68</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 			</tools>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -170,11 +170,11 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>36</power>
-					<cooldownTime>0.79</cooldownTime>
+					<power>32</power>
+					<cooldownTime>0.92</cooldownTime>
 					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>3.125</armorPenetrationBlunt>
-					<armorPenetrationSharp>12.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.42</armorPenetrationBlunt>
+					<armorPenetrationSharp>9.68</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 			</tools>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -78,7 +78,7 @@
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<label>Head</label>
+					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
@@ -118,7 +118,7 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<label>Head</label>
+					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
@@ -257,22 +257,22 @@
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<label>Head</label>
+					<label>head</label>
 					<capacities>
-						<li>Blunt</li>
+					<li>Blunt</li>
 					</capacities>
-					<power>53</power>
+					<power>41</power>
 					<extraMeleeDamages>
 					<li>
 						<def>EMP</def>
-						<amount>9</amount>
+						<amount>5</amount>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>1.81</cooldownTime>
-					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>24</armorPenetrationBlunt>
+					<cooldownTime>2.76</cooldownTime>
+					<armorPenetrationBlunt>157.5</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-				</li>
+					<chanceFactor>0.30</chanceFactor>
+				</li>				
 			</tools>
 		</value>
 	</Operation>
@@ -334,18 +334,18 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>59</power>
+					<power>40</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
-						<amount>8</amount>
-						<chance>0.2</chance>
+						<amount>5</amount>
+						<chance>0.3</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>0.91</cooldownTime>
+					<cooldownTime>2.06</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>7.84</armorPenetrationBlunt>
-					<armorPenetrationSharp>15.68</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.20</armorPenetrationBlunt>
+					<armorPenetrationSharp>16</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -353,17 +353,17 @@
 					<capacities>
 					<li>Stab</li>
 					</capacities>
-					<power>28</power>
+					<power>17</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
-						<amount>8</amount>
+						<amount>3</amount>
 						<chance>0.2</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>2</cooldownTime>
-					<armorPenetrationBlunt>4.84</armorPenetrationBlunt>
-					<armorPenetrationSharp>24.20</armorPenetrationSharp>
+					<cooldownTime>0.99</cooldownTime>
+					<armorPenetrationBlunt>3.24</armorPenetrationBlunt>
+					<armorPenetrationSharp>32.4</armorPenetrationSharp>
 				</li>				
 			</tools>
 		</value>


### PR DESCRIPTION
## Changes
- Zeushammer: balanced to correspond with CE Melee power maul.
- Plasmasword: balanced to correspond with CE Melee wraith blade.
- Monoblade: reduced damage, increased cooldown.

## Reasoning
- Initial stats for Ultra tech melee weapons too powerful, balance them to put them roughly on part with the high-rarity CE Melee weapons.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Tested in game; combat versus various enemies.
- [] Playtested a colony (specify how long)
