### PR TITLE
Update supported mod list (1 rename, 11 removals)

### DIFF
--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -31,12 +31,9 @@ Mod |
 [SS]Maid Project	|
 [SYR] Thrumkin	|
 A Dog Said...	|
-A RimWorld of Magic	|
-Alpha Animals	|
 Android Tiers	|
 Android Tiers++	|
 Androids	|
-AnimalCollabProj	|
 Apparello 2	|
 Arachne Race	|
 Area Rugs	|
@@ -59,7 +56,6 @@ FashionRIMsta	|
 Fate Grand Order - Styles Apparel Pack	|
 Ferrex Race	|
 Flak Dusters	|
-Forsakens	|
 Gas Traps And Shells	|
 Girls' Frontline Apparel Pack	|
 Girls' Frontline Styles - 404 Team	|
@@ -70,9 +66,6 @@ Hand 'n' Footwear	|
 High Caliber	|
 Jernfalk's Standalone Horses	|
 K.L.K - Styles Apparel Pack	|
-Kenshi Hiver Race	|
-Kenshi Shek Race	|
-Kenshi Skeleton Race	|
 Kijin Race 2.0     	|     
 Kill la Kill Styles Pack    	|   
 Kurin, The Three Tailed Fox	|
@@ -87,8 +80,6 @@ MiningCo. MiningHelmet	|
 Misc. Robots	|
 More Mechanoids	|
 More Practical Traits	|
-More Vanilla Turrets	|
-NewRatkinPlus	|
 Ni'Hal	|
 Orassans	|
 Penguin	|
@@ -103,7 +94,7 @@ Rimefeller	|
 RimEffect - Asari of the Rims	|
 Rimfire	|
 Save Our Ship 2	|
-Sergals, Gnolls and Lions	|
+Sergals, Gnolls, Lions and Frogs	|
 Simply More Melee	|
 Soviet Armory	|
 Spartan Foundry	|
@@ -119,7 +110,6 @@ Vanilla Weapons Expanded Quickdraw	|
 Vanilla-Friendly Animal Surgery	|
 Vanilla-Friendly Weapon Expansion	|
 Vulpine Race Pack	|
-Warhammer: Gor	|
 Weapons+	|
 WWII Soviet Faction	|
 Xenn Race	|


### PR DESCRIPTION
## Changes
* Rename Sergals, Gnolls and Lions to Sergals, Gnolls, Lions and Frogs
* Temporarily delist 11 mods whose patches have not yet been ported from FastTrack and missed the CE 2.0 release deadline

Note: these are documentation changes only, and have no effect on in-game behaviour