### PR TITLE
Vanilla Expanded Adjustments

### DIFF
--- a/Patches/Vanilla Armour Expanded/Patch_Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Armor_Industrial.xml
@@ -14,8 +14,8 @@
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/Mass</xpath>
 				<value>
 					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-					<Mass>10</Mass>
+					<WornBulk>1.5</WornBulk>
+					<Mass>3.5</Mass>
 					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 				</value>
 			</li>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -283,6 +283,7 @@
 					
 					<weaponTags>
 					<li>Gun</li>
+					<li>CE_OneHandedWeapon</li>	
 					</weaponTags>
 					<researchPrerequisite>Gunsmithing</researchPrerequisite>
 				</li>


### PR DESCRIPTION
## Changes
- Vanilla Armor Expanded - Reduced bulletproof vest weight, increased bulk.
- Vanilla Weapons Expanded - Add one-handed tag to sawed-off shotgun
## Reasoning
- While 10 is probably appropriate for a vest with a hard plate, the bulletproof vest is stated to be soft armor, so the weight has been reduced. Bulk also increased to something closer to other armor.
- Sawed off stats were generated with the intention of making it 1-handed, I just forgot the tag first time around.