### PR TITLE
EPOE compatibility patch - added AdvancedPowerClaw

### DIFF
--- a/Patches/EPOE/Bionics.xml
+++ b/Patches/EPOE/Bionics.xml
@@ -183,6 +183,24 @@
             </tools>
       	</value>
       </li>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/HediffDef[defName="AdvancedPowerClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>claw</label>
+              <capacities>
+                <li>Scratch</li>
+              </capacities>
+              <power>23</power>
+              <cooldownTime>0.77</cooldownTime>
+              <armorPenetrationSharp>1</armorPenetrationSharp>
+              <armorPenetrationBlunt>5</armorPenetrationBlunt>
+              <linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+            </li>
+          </tools>
+        </value>
+      </li>
     </operations>
   </Operation>
 


### PR DESCRIPTION
It was missing, this is about 33% more dps than normal powerclaw
I'm not sure about armor piercing.

Seems to work properly, I checked using the ingame "list melee verbs".

Normal power claw for reference:
```
<tools>
	<li Class="CombatExtended.ToolCE">
		<label>claw</label>
		<capacities>
			<li>Scratch</li>
		</capacities>
		<power>21</power>
		<cooldownTime>0.89</cooldownTime>
		<armorPenetrationSharp>0.8</armorPenetrationSharp>
		<armorPenetrationBlunt>4</armorPenetrationBlunt>
		<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
	</li>
</tools>
```
